### PR TITLE
Fix global state machine

### DIFF
--- a/CSC8503CoreClasses/State.h
+++ b/CSC8503CoreClasses/State.h
@@ -10,11 +10,11 @@ namespace NCL {
 			State(StateUpdateFunction someFunc) {
 				func		= someFunc;
 			}
-			void Update(float dt)  {
-				if (func != nullptr) {
-					func(dt);
-				}
-			}
+			
+			virtual void Update(float dt) = 0;
+
+			virtual void OnEnter() { std::cout << "On Enter"; }
+			virtual void OnExit() { std::cout << "On Exit"; }
 		protected:
 			StateUpdateFunction func;
 		};

--- a/CSC8503CoreClasses/State.h
+++ b/CSC8503CoreClasses/State.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "StateMachine.h"
+#include "StateTransition.h"
+
+
 namespace NCL {
 	namespace CSC8503 {
 		typedef std::function<void(float)> StateUpdateFunction;
@@ -13,8 +17,8 @@ namespace NCL {
 			
 			virtual void Update(float dt) = 0;
 
-			virtual void OnEnter() { std::cout << "On Enter"; }
-			virtual void OnExit() { std::cout << "On Exit"; }
+			virtual void OnEnter() {  }
+			virtual void OnExit() {  }
 		protected:
 			StateUpdateFunction func;
 		};

--- a/CSC8503CoreClasses/StateMachine.cpp
+++ b/CSC8503CoreClasses/StateMachine.cpp
@@ -38,7 +38,9 @@ void StateMachine::Update(float dt) {
 		for (auto& i = range.first; i != range.second; ++i) {
 			if (i->second->CanTransition()) {
 				State* newState = i->second->GetDestinationState();
+				activeState->OnExit();
 				activeState = newState;
+				newState->OnEnter();
 			}
 		}
 	}

--- a/CSC8503CoreClasses/StateMachine.h
+++ b/CSC8503CoreClasses/StateMachine.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <map>
-
+#include <vector>
 namespace NCL {
 	namespace CSC8503 {
 		class State;

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 project(client)
 
-add_executable(client main.cpp Client.cpp Renderer.cpp TutorialGame.cpp Font.cpp "States/GameStateInGameplay.h" "States/GameStateInGameplay.cpp")
+add_executable(client main.cpp Client.cpp Renderer.cpp TutorialGame.cpp Font.cpp "States/GameStateInGameplay.h" "States/GameStateInGameplay.cpp" "States/GameStateInactive.cpp" "States/GameStateInactive.h")
 target_include_directories(client PUBLIC ../NCLCoreClasses ../CSC8503CoreClasses ../OpenGLRendering ./ ../Replicated ../FreetypeRenderer/include)
 target_link_libraries(client PUBLIC NCLCoreClasses CSC8503CoreClasses OpenGLRendering replicated freetype)

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 project(client)
 
-add_executable(client main.cpp Client.cpp Renderer.cpp TutorialGame.cpp Font.cpp "States/GameStateInGameplay.h" "States/GameStateInGameplay.cpp" "States/GameStateInactive.cpp" "States/GameStateInactive.h" "States/GameStateLoading.cpp" "States/GameStateLoading.h")
+add_executable(client main.cpp Client.cpp Renderer.cpp TutorialGame.cpp Font.cpp "States/GameStateInGameplay.h" "States/GameStateInGameplay.cpp" "States/GameStateInactive.cpp" "States/GameStateInactive.h" "States/GameStateLoading.cpp" "States/GameStateLoading.h" "States/GameStateMenu.cpp" "States/GameStateMenu.h" "ClientGameStateMachine.h" "ClientGameStateMachine.cpp")
 target_include_directories(client PUBLIC ../NCLCoreClasses ../CSC8503CoreClasses ../OpenGLRendering ./ ../Replicated ../FreetypeRenderer/include)
 target_link_libraries(client PUBLIC NCLCoreClasses CSC8503CoreClasses OpenGLRendering replicated freetype)

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -1,6 +1,16 @@
 cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 project(client)
 
-add_executable(client main.cpp Client.cpp Renderer.cpp TutorialGame.cpp Font.cpp "States/GameStateInGameplay.h" "States/GameStateInGameplay.cpp" "States/GameStateInactive.cpp" "States/GameStateInactive.h" "States/GameStateLoading.cpp" "States/GameStateLoading.h" "States/GameStateMenu.cpp" "States/GameStateMenu.h" "ClientGameStateMachine.h" "ClientGameStateMachine.cpp")
-target_include_directories(client PUBLIC ../NCLCoreClasses ../CSC8503CoreClasses ../OpenGLRendering ./ ../Replicated ../FreetypeRenderer/include)
+add_executable(client 
+main.cpp 
+Client.cpp 
+Renderer.cpp 
+TutorialGame.cpp 
+Font.cpp 
+"States/GameStateInGameplay.cpp" 
+"States/GameStateInactive.cpp" 
+"States/GameStateLoading.cpp" 
+"States/GameStateMenu.cpp" 
+"ClientGameStateMachine.cpp")
+target_include_directories(client PUBLIC ../NCLCoreClasses ../CSC8503CoreClasses ../OpenGLRendering ./ ../Replicated ../FreetypeRenderer/include ./States)
 target_link_libraries(client PUBLIC NCLCoreClasses CSC8503CoreClasses OpenGLRendering replicated freetype)

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 project(client)
 
-add_executable(client main.cpp Client.cpp Renderer.cpp TutorialGame.cpp Font.cpp "States/GameStateInGameplay.h" "States/GameStateInGameplay.cpp" "States/GameStateInactive.cpp" "States/GameStateInactive.h")
+add_executable(client main.cpp Client.cpp Renderer.cpp TutorialGame.cpp Font.cpp "States/GameStateInGameplay.h" "States/GameStateInGameplay.cpp" "States/GameStateInactive.cpp" "States/GameStateInactive.h" "States/GameStateLoading.cpp" "States/GameStateLoading.h")
 target_include_directories(client PUBLIC ../NCLCoreClasses ../CSC8503CoreClasses ../OpenGLRendering ./ ../Replicated ../FreetypeRenderer/include)
 target_link_libraries(client PUBLIC NCLCoreClasses CSC8503CoreClasses OpenGLRendering replicated freetype)

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 project(client)
 
-add_executable(client main.cpp Client.cpp Renderer.cpp TutorialGame.cpp Font.cpp)
+add_executable(client main.cpp Client.cpp Renderer.cpp TutorialGame.cpp Font.cpp "States/GameStateInGameplay.h" "States/GameStateInGameplay.cpp")
 target_include_directories(client PUBLIC ../NCLCoreClasses ../CSC8503CoreClasses ../OpenGLRendering ./ ../Replicated ../FreetypeRenderer/include)
 target_link_libraries(client PUBLIC NCLCoreClasses CSC8503CoreClasses OpenGLRendering replicated freetype)

--- a/Client/ClientGameStateMachine.cpp
+++ b/Client/ClientGameStateMachine.cpp
@@ -1,45 +1,63 @@
-#pragma once
-#include "StateMachine.h"
-#include <vector>
-#include "Renderer.h"
-#include "GameWorld.h"
+#include "ClientGameStateMachine.h"
+#include "State.h"
+#include "StateTransition.h"
+#include "GameStateInactive.h"
+#include "GameStateLoading.h"
+#include "GameStateMenu.h"
+#include "GameStateInGameplay.h"
+using namespace NCL;
+using namespace CSC8503;
+ClientGameStateMachine::ClientGameStateMachine() : StateMachine()
+{
+	gameWorld = new GameWorld();
+	renderer = new GameTechRenderer(*gameWorld);
+	currentClientState = ClientStates::InactiveState;
+	InitialiseClientStateMachine();
+}
 
-namespace NCL {
-	namespace CSC8503 {
-		enum ClientStates {
-			InactiveState,
-			LoadingState,
-			MenuState,
-			InGameplayState
-		};
-		class ClientGameStateMachine : public StateMachine {
-		public:
-			ClientGameStateMachine();
-			virtual ~ClientGameStateMachine();
-			std::vector<State*> GetAvailableLevels()
-			{
-				return availableLevels;
-			}
-			void SetClientState(ClientStates clientState)
-			{
-				currentClientState = clientState;
-			}
-		protected:
+ClientGameStateMachine::~ClientGameStateMachine()
+{
+}
+
+void ClientGameStateMachine::InitialiseClientStateMachine()
+{
+	//*
+	Inactive* clientInactive = new Inactive(renderer, gameWorld);
+	Loading* clientLoading = new Loading(renderer, gameWorld);
+	Menu* clientMenu = new Menu(renderer, gameWorld);
+	InGameplay* clientInGameplay = new InGameplay(renderer, gameWorld);
+
+	StateTransition* inactiveToLoading = new StateTransition(clientInactive, clientLoading, [&](void)->bool {
+		return ForceTransition(Window::GetKeyboard()->KeyPressed(KeyboardKeys::SPACE), ClientStates::LoadingState);
+		});
+	StateTransition* loadingToMenu = new StateTransition(clientLoading, clientMenu, [&](void)->bool {
+		return ForceTransition(Window::GetKeyboard()->KeyPressed(KeyboardKeys::L), ClientStates::MenuState);
+		});
+	StateTransition* menuToLoading = new StateTransition(clientMenu, clientLoading, [&](void)->bool {
+		return ForceTransition(Window::GetKeyboard()->KeyPressed(KeyboardKeys::SPACE), ClientStates::LoadingState);
+		});
+	StateTransition* loadingToInGameplay = new StateTransition(clientLoading, clientInGameplay, [&](void)->bool {
+		return ForceTransition(Window::GetKeyboard()->KeyPressed(KeyboardKeys::SPACE), ClientStates::InGameplayState);
+		});
+	StateTransition* inGameplayToLoading = new StateTransition(clientInGameplay, clientLoading, [&](void)->bool {
+		int tester = clientInGameplay->ExitType();
+		return ForceTransition(tester != ExitStates::Invalid, ClientStates::LoadingState);
+		});
+
+	this->AddState(clientInactive);
+	this->AddState(clientLoading);
+	this->AddState(clientMenu);
+	this->AddState(clientInGameplay);
+
+	this->AddTransition(inactiveToLoading);
+	this->AddTransition(loadingToMenu);
+	this->AddTransition(menuToLoading);
+	this->AddTransition(loadingToInGameplay);
+	this->AddTransition(inGameplayToLoading);
+}
 
 
-			ClientStates currentClientState;
-			std::vector<State*> availableLevels;
-			void InitialiseClientStateMachine();
-
-			bool ForceTransition(bool hasConidtionMet, ClientStates stateSwitchTo);
-
-#ifdef USEVULKAN
-			GameTechVulkanRenderer* renderer;
-#else
-			GameTechRenderer* renderer;
-#endif
-
-			GameWorld* gameWorld;
-		};
-	}
+bool ClientGameStateMachine::ForceTransition(bool hasConidtionMet, ClientStates stateSwitchTo) {
+	if (hasConidtionMet) currentClientState = stateSwitchTo;
+	return hasConidtionMet;
 }

--- a/Client/ClientGameStateMachine.cpp
+++ b/Client/ClientGameStateMachine.cpp
@@ -1,0 +1,45 @@
+#pragma once
+#include "StateMachine.h"
+#include <vector>
+#include "Renderer.h"
+#include "GameWorld.h"
+
+namespace NCL {
+	namespace CSC8503 {
+		enum ClientStates {
+			InactiveState,
+			LoadingState,
+			MenuState,
+			InGameplayState
+		};
+		class ClientGameStateMachine : public StateMachine {
+		public:
+			ClientGameStateMachine();
+			virtual ~ClientGameStateMachine();
+			std::vector<State*> GetAvailableLevels()
+			{
+				return availableLevels;
+			}
+			void SetClientState(ClientStates clientState)
+			{
+				currentClientState = clientState;
+			}
+		protected:
+
+
+			ClientStates currentClientState;
+			std::vector<State*> availableLevels;
+			void InitialiseClientStateMachine();
+
+			bool ForceTransition(bool hasConidtionMet, ClientStates stateSwitchTo);
+
+#ifdef USEVULKAN
+			GameTechVulkanRenderer* renderer;
+#else
+			GameTechRenderer* renderer;
+#endif
+
+			GameWorld* gameWorld;
+		};
+	}
+}

--- a/Client/ClientGameStateMachine.h
+++ b/Client/ClientGameStateMachine.h
@@ -1,0 +1,45 @@
+#pragma once
+#include "StateMachine.h"
+#include <vector>
+#include "Renderer.h"
+#include "GameWorld.h"
+
+namespace NCL {
+	namespace CSC8503 {
+		enum ClientStates {
+			InactiveState,
+			LoadingState,
+			MenuState,
+			InGameplayState
+		};
+		class ClientGameStateMachine : public StateMachine {
+		public:
+			ClientGameStateMachine();
+			virtual ~ClientGameStateMachine();
+			std::vector<State*> GetAvailableLevels()
+			{
+				return availableLevels;
+			}
+			void SetClientState(ClientStates clientState)
+			{
+				currentClientState = clientState;
+			}
+		protected:
+
+
+			ClientStates currentClientState;
+			std::vector<State*> availableLevels;
+			void InitialiseClientStateMachine();
+
+			bool ForceTransition(bool hasConidtionMet, ClientStates stateSwitchTo);
+
+#ifdef USEVULKAN
+			GameTechVulkanRenderer* renderer;
+#else
+			GameTechRenderer* renderer;
+#endif
+
+			GameWorld* gameWorld;
+		};
+	}
+}

--- a/Client/States/GameStateInGameplay.cpp
+++ b/Client/States/GameStateInGameplay.cpp
@@ -1,0 +1,513 @@
+#include "GameStateInGameplay.h"
+#include "GameWorld.h"
+#include "PhysicsObject.h"
+#include "RenderObject.h"
+#include "TextureLoader.h"
+
+#include "PositionConstraint.h"
+#include "OrientationConstraint.h"
+using namespace NCL;
+using namespace CSC8503;
+#
+InGameplay::InGameplay(GameTechRenderer* rendererRef, GameWorld* gameWorldRef) : State() {
+	renderer = rendererRef;
+	world = gameWorldRef;
+}
+
+InGameplay::~InGameplay() {
+
+	delete cubeMesh;
+	delete sphereMesh;
+	delete charMesh;
+	delete enemyMesh;
+	delete bonusMesh;
+
+	delete basicTex;
+	delete basicShader;
+
+	delete physics;
+}
+
+void InGameplay::OnEnter() {
+	std::cout << "GAME LOADED\n";
+	//g = new TutorialGame();
+
+	physics = new PhysicsSystem(*world);
+
+	forceMagnitude = 10.0f;
+	useGravity = false;
+	inSelectionMode = false;
+
+	InitialiseAssets();
+}
+void InGameplay::OnExit() {
+	this->~InGameplay();
+	world->ClearAndErase();
+	renderer->Render();
+}
+
+int InGameplay::ExitType() {
+
+	if (Window::GetKeyboard()->KeyDown(KeyboardKeys::L))
+	{
+		return ExitStates::Win;
+	}
+	return ExitStates::Invalid;
+}
+
+void InGameplay::Update(float dt) {
+	Debug::Print("PRESS L TO END GAME", Vector2(10, 20));
+	if (!inSelectionMode) {
+		world->GetMainCamera()->UpdateCamera(dt);
+	}
+	if (lockedObject != nullptr) {
+		Vector3 objPos = lockedObject->GetTransform().GetPosition();
+		Vector3 camPos = objPos + lockedOffset;
+
+		Matrix4 temp = Matrix4::BuildViewMatrix(camPos, objPos, Vector3(0, 1, 0));
+
+		Matrix4 modelMat = temp.Inverse();
+
+		Quaternion q(modelMat);
+		Vector3 angles = q.ToEuler(); //nearly there now!
+
+		world->GetMainCamera()->SetPosition(camPos);
+		world->GetMainCamera()->SetPitch(angles.x);
+		world->GetMainCamera()->SetYaw(angles.y);
+	}
+
+	UpdateKeys();
+
+	if (useGravity) {
+		Debug::Print("(G)ravity on", Vector2(5, 95), Debug::RED);
+	}
+	else {
+		Debug::Print("(G)ravity off", Vector2(5, 95), Debug::RED);
+	}
+
+	RayCollision closestCollision;
+	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::K) && selectionObject) {
+		Vector3 rayPos;
+		Vector3 rayDir;
+
+		rayDir = selectionObject->GetTransform().GetOrientation() * Vector3(0, 0, -1);
+
+		rayPos = selectionObject->GetTransform().GetPosition();
+
+		Ray r = Ray(rayPos, rayDir);
+
+		if (world->Raycast(r, closestCollision, true, selectionObject)) {
+			if (objClosest) {
+				objClosest->GetRenderObject()->SetColour(Vector4(1, 1, 1, 1));
+			}
+			objClosest = (GameObject*)closestCollision.node;
+
+			objClosest->GetRenderObject()->SetColour(Vector4(1, 0, 1, 1));
+		}
+	}
+
+	Debug::DrawLine(Vector3(), Vector3(0, 100, 0), Vector4(1, 0, 0, 1));
+
+	SelectObject();
+	MoveSelectedObject();
+
+	world->UpdateWorld(dt);
+	renderer->Update(dt);
+	physics->Update(dt);
+
+	renderer->Render();
+	Debug::UpdateRenderables(dt);
+}
+
+
+void InGameplay::InitialiseAssets() {
+	cubeMesh = renderer->LoadMesh("cube.msh");
+	sphereMesh = renderer->LoadMesh("sphere.msh");
+	charMesh = renderer->LoadMesh("goat.msh");
+	enemyMesh = renderer->LoadMesh("Keeper.msh");
+	bonusMesh = renderer->LoadMesh("apple.msh");
+	capsuleMesh = renderer->LoadMesh("capsule.msh");
+
+	basicTex = renderer->LoadTexture("checkerboard.png");
+	basicShader = renderer->LoadShader("scene.vert", "scene.frag");
+
+	InitCamera();
+	InitWorld();
+}
+
+
+void InGameplay::UpdateKeys() {
+	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::F1)) {
+		InitWorld(); //We can reset the simulation at any time with F1
+		selectionObject = nullptr;
+	}
+
+	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::F2)) {
+		InitCamera(); //F2 will reset the camera to a specific default place
+	}
+
+	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::G)) {
+		useGravity = !useGravity; //Toggle gravity!
+		physics->UseGravity(useGravity);
+	}
+	//Running certain physics updates in a consistent order might cause some
+	//bias in the calculations - the same objects might keep 'winning' the constraint
+	//allowing the other one to stretch too much etc. Shuffling the order so that it
+	//is random every frame can help reduce such bias.
+	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::F9)) {
+		world->ShuffleConstraints(true);
+	}
+	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::F10)) {
+		world->ShuffleConstraints(false);
+	}
+
+	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::F7)) {
+		world->ShuffleObjects(true);
+	}
+	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::F8)) {
+		world->ShuffleObjects(false);
+	}
+
+	if (lockedObject) {
+		LockedObjectMovement();
+	}
+	else {
+		DebugObjectMovement();
+	}
+}
+
+void InGameplay::LockedObjectMovement() {
+	Matrix4 view = world->GetMainCamera()->BuildViewMatrix();
+	Matrix4 camWorld = view.Inverse();
+
+	Vector3 rightAxis = Vector3(camWorld.GetColumn(0)); //view is inverse of model!
+
+	//forward is more tricky -  camera forward is 'into' the screen...
+	//so we can take a guess, and use the cross of straight up, and
+	//the right axis, to hopefully get a vector that's good enough!
+
+	Vector3 fwdAxis = Vector3::Cross(Vector3(0, 1, 0), rightAxis);
+	fwdAxis.y = 0.0f;
+	fwdAxis.Normalise();
+
+
+	if (Window::GetKeyboard()->KeyDown(KeyboardKeys::UP)) {
+		selectionObject->GetPhysicsObject()->AddForce(fwdAxis);
+	}
+
+	if (Window::GetKeyboard()->KeyDown(KeyboardKeys::DOWN)) {
+		selectionObject->GetPhysicsObject()->AddForce(-fwdAxis);
+	}
+
+	if (Window::GetKeyboard()->KeyDown(KeyboardKeys::NEXT)) {
+		selectionObject->GetPhysicsObject()->AddForce(Vector3(0, -10, 0));
+	}
+}
+
+void InGameplay::DebugObjectMovement() {
+	//If we've selected an object, we can manipulate it with some key presses
+	if (inSelectionMode && selectionObject) {
+		//Twist the selected object!
+		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::LEFT)) {
+			selectionObject->GetPhysicsObject()->AddTorque(Vector3(-10, 0, 0));
+		}
+
+		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::RIGHT)) {
+			selectionObject->GetPhysicsObject()->AddTorque(Vector3(10, 0, 0));
+		}
+
+		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::NUM7)) {
+			selectionObject->GetPhysicsObject()->AddTorque(Vector3(0, 10, 0));
+		}
+
+		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::NUM8)) {
+			selectionObject->GetPhysicsObject()->AddTorque(Vector3(0, -10, 0));
+		}
+
+		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::RIGHT)) {
+			selectionObject->GetPhysicsObject()->AddTorque(Vector3(10, 0, 0));
+		}
+
+		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::UP)) {
+			selectionObject->GetPhysicsObject()->AddForce(Vector3(0, 0, -10));
+		}
+
+		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::DOWN)) {
+			selectionObject->GetPhysicsObject()->AddForce(Vector3(0, 0, 10));
+		}
+
+		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::NUM5)) {
+			selectionObject->GetPhysicsObject()->AddForce(Vector3(0, -10, 0));
+		}
+	}
+}
+
+void InGameplay::InitCamera() {
+	world->GetMainCamera()->SetNearPlane(0.1f);
+	world->GetMainCamera()->SetFarPlane(500.0f);
+	world->GetMainCamera()->SetPitch(-15.0f);
+	world->GetMainCamera()->SetYaw(315.0f);
+	world->GetMainCamera()->SetPosition(Vector3(-60, 40, 60));
+	lockedObject = nullptr;
+}
+
+void InGameplay::InitWorld() {
+	world->ClearAndErase();
+	physics->Clear();
+
+	InitMixedGridWorld(15, 15, 3.5f, 3.5f);
+
+	InitGameExamples();
+	InitDefaultFloor();
+}
+
+GameObject* InGameplay::AddFloorToWorld(const Vector3& position) {
+	GameObject* floor = new GameObject();
+
+	Vector3 floorSize = Vector3(200, 2, 200);
+	AABBVolume* volume = new AABBVolume(floorSize);
+	floor->SetBoundingVolume((CollisionVolume*)volume);
+	floor->GetTransform()
+		.SetScale(floorSize * 2)
+		.SetPosition(position);
+
+	floor->SetRenderObject(new RenderObject(&floor->GetTransform(), cubeMesh, basicTex, basicShader));
+	floor->SetPhysicsObject(new PhysicsObject(&floor->GetTransform(), floor->GetBoundingVolume()));
+
+	floor->GetPhysicsObject()->SetInverseMass(0);
+	floor->GetPhysicsObject()->InitCubeInertia();
+
+	world->AddGameObject(floor);
+
+	return floor;
+}
+
+GameObject* InGameplay::AddSphereToWorld(const Vector3& position, float radius, float inverseMass) {
+	GameObject* sphere = new GameObject();
+	//Change to test
+
+	Vector3 sphereSize = Vector3(radius, radius, radius);
+	SphereVolume* volume = new SphereVolume(radius);
+	sphere->SetBoundingVolume((CollisionVolume*)volume);
+
+	sphere->GetTransform()
+		.SetScale(sphereSize)
+		.SetPosition(position);
+
+	sphere->SetRenderObject(new RenderObject(&sphere->GetTransform(), sphereMesh, basicTex, basicShader));
+	sphere->SetPhysicsObject(new PhysicsObject(&sphere->GetTransform(), sphere->GetBoundingVolume()));
+
+	sphere->GetPhysicsObject()->SetInverseMass(inverseMass);
+	sphere->GetPhysicsObject()->InitSphereInertia();
+
+	world->AddGameObject(sphere);
+
+	return sphere;
+}
+
+GameObject* InGameplay::AddCubeToWorld(const Vector3& position, Vector3 dimensions, float inverseMass) {
+	GameObject* cube = new GameObject();
+
+	AABBVolume* volume = new AABBVolume(dimensions);
+	cube->SetBoundingVolume((CollisionVolume*)volume);
+
+	cube->GetTransform()
+		.SetPosition(position)
+		.SetScale(dimensions * 2);
+
+	cube->SetRenderObject(new RenderObject(&cube->GetTransform(), cubeMesh, basicTex, basicShader));
+	cube->SetPhysicsObject(new PhysicsObject(&cube->GetTransform(), cube->GetBoundingVolume()));
+
+	cube->GetPhysicsObject()->SetInverseMass(inverseMass);
+	cube->GetPhysicsObject()->InitCubeInertia();
+
+	world->AddGameObject(cube);
+
+	return cube;
+}
+
+GameObject* InGameplay::AddPlayerToWorld(const Vector3& position) {
+	float meshSize = 1.0f;
+	float inverseMass = 0.5f;
+
+	GameObject* character = new GameObject();
+	SphereVolume* volume = new SphereVolume(1.0f);
+
+	character->SetBoundingVolume((CollisionVolume*)volume);
+
+	character->GetTransform()
+		.SetScale(Vector3(meshSize, meshSize, meshSize))
+		.SetPosition(position);
+
+	character->SetRenderObject(new RenderObject(&character->GetTransform(), charMesh, nullptr, basicShader));
+	character->SetPhysicsObject(new PhysicsObject(&character->GetTransform(), character->GetBoundingVolume()));
+
+	character->GetPhysicsObject()->SetInverseMass(inverseMass);
+	character->GetPhysicsObject()->InitSphereInertia();
+
+	world->AddGameObject(character);
+
+	return character;
+}
+
+GameObject* InGameplay::AddEnemyToWorld(const Vector3& position) {
+	float meshSize = 3.0f;
+	float inverseMass = 0.5f;
+
+	GameObject* character = new GameObject();
+
+	AABBVolume* volume = new AABBVolume(Vector3(0.3f, 0.9f, 0.3f) * meshSize);
+	character->SetBoundingVolume((CollisionVolume*)volume);
+
+	character->GetTransform()
+		.SetScale(Vector3(meshSize, meshSize, meshSize))
+		.SetPosition(position);
+
+	character->SetRenderObject(new RenderObject(&character->GetTransform(), enemyMesh, nullptr, basicShader));
+	character->SetPhysicsObject(new PhysicsObject(&character->GetTransform(), character->GetBoundingVolume()));
+
+	character->GetPhysicsObject()->SetInverseMass(inverseMass);
+	character->GetPhysicsObject()->InitSphereInertia();
+
+	world->AddGameObject(character);
+
+	return character;
+}
+
+GameObject* InGameplay::AddBonusToWorld(const Vector3& position) {
+	GameObject* apple = new GameObject();
+
+	SphereVolume* volume = new SphereVolume(0.5f);
+	apple->SetBoundingVolume((CollisionVolume*)volume);
+	apple->GetTransform()
+		.SetScale(Vector3(2, 2, 2))
+		.SetPosition(position);
+
+	apple->SetRenderObject(new RenderObject(&apple->GetTransform(), bonusMesh, nullptr, basicShader));
+	apple->SetPhysicsObject(new PhysicsObject(&apple->GetTransform(), apple->GetBoundingVolume()));
+
+	apple->GetPhysicsObject()->SetInverseMass(1.0f);
+	apple->GetPhysicsObject()->InitSphereInertia();
+
+	world->AddGameObject(apple);
+
+	return apple;
+}
+
+void InGameplay::InitDefaultFloor() {
+	AddFloorToWorld(Vector3(0, -20, 0));
+}
+
+void InGameplay::InitGameExamples() {
+	AddPlayerToWorld(Vector3(0, 5, 0));
+	AddEnemyToWorld(Vector3(5, 5, 0));
+	AddBonusToWorld(Vector3(10, 5, 0));
+}
+
+void InGameplay::InitSphereGridWorld(int numRows, int numCols, float rowSpacing, float colSpacing, float radius) {
+	for (int x = 0; x < numCols; ++x) {
+		for (int z = 0; z < numRows; ++z) {
+			Vector3 position = Vector3(x * colSpacing, 10.0f, z * rowSpacing);
+			AddSphereToWorld(position, radius, 1.0f);
+		}
+	}
+	AddFloorToWorld(Vector3(0, -2, 0));
+}
+
+void InGameplay::InitMixedGridWorld(int numRows, int numCols, float rowSpacing, float colSpacing) {
+	float sphereRadius = 1.0f;
+	Vector3 cubeDims = Vector3(1, 1, 1);
+
+	for (int x = 0; x < numCols; ++x) {
+		for (int z = 0; z < numRows; ++z) {
+			Vector3 position = Vector3(x * colSpacing, 10.0f, z * rowSpacing);
+
+			if (rand() % 2) {
+				AddCubeToWorld(position, cubeDims);
+			}
+			else {
+				AddSphereToWorld(position, sphereRadius);
+			}
+		}
+	}
+}
+
+void InGameplay::InitCubeGridWorld(int numRows, int numCols, float rowSpacing, float colSpacing, const Vector3& cubeDims) {
+	for (int x = 1; x < numCols + 1; ++x) {
+		for (int z = 1; z < numRows + 1; ++z) {
+			Vector3 position = Vector3(x * colSpacing, 10.0f, z * rowSpacing);
+			AddCubeToWorld(position, cubeDims, 1.0f);
+		}
+	}
+}
+
+bool InGameplay::SelectObject() {
+	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::Q)) {
+		inSelectionMode = !inSelectionMode;
+		if (inSelectionMode) {
+			Window::GetWindow()->ShowOSPointer(true);
+			Window::GetWindow()->LockMouseToWindow(false);
+		}
+		else {
+			Window::GetWindow()->ShowOSPointer(false);
+			Window::GetWindow()->LockMouseToWindow(true);
+		}
+	}
+	if (inSelectionMode) {
+		Debug::Print("Press Q to change to camera mode!", Vector2(5, 85));
+
+		if (Window::GetMouse()->ButtonDown(NCL::MouseButtons::LEFT)) {
+			if (selectionObject) {	//set colour to deselected;
+				selectionObject->GetRenderObject()->SetColour(Vector4(1, 1, 1, 1));
+				selectionObject = nullptr;
+			}
+
+			Ray ray = CollisionDetection::BuildRayFromMouse(*world->GetMainCamera());
+
+			RayCollision closestCollision;
+			if (world->Raycast(ray, closestCollision, true)) {
+				selectionObject = (GameObject*)closestCollision.node;
+
+				selectionObject->GetRenderObject()->SetColour(Vector4(0, 1, 0, 1));
+				return true;
+			}
+			else {
+				return false;
+			}
+		}
+		if (Window::GetKeyboard()->KeyPressed(NCL::KeyboardKeys::L)) {
+			if (selectionObject) {
+				if (lockedObject == selectionObject) {
+					lockedObject = nullptr;
+				}
+				else {
+					lockedObject = selectionObject;
+				}
+			}
+		}
+	}
+	else {
+		Debug::Print("Press Q to change to select mode!", Vector2(5, 85));
+	}
+	return false;
+}
+
+void InGameplay::MoveSelectedObject() {
+	Debug::Print("Click Force:" + std::to_string(forceMagnitude), Vector2(5, 90));
+	forceMagnitude += Window::GetMouse()->GetWheelMovement() * 100.0f;
+
+	if (!selectionObject) {
+		return;//we haven't selected anything!
+	}
+	//Push the selected object!
+	if (Window::GetMouse()->ButtonPressed(NCL::MouseButtons::RIGHT)) {
+		Ray ray = CollisionDetection::BuildRayFromMouse(*world->GetMainCamera());
+
+		RayCollision closestCollision;
+		if (world->Raycast(ray, closestCollision, true)) {
+			if (closestCollision.node == selectionObject) {
+				selectionObject->GetPhysicsObject()->AddForceAtPosition(ray.GetDirection() * forceMagnitude, closestCollision.collidedAt);
+			}
+		}
+	}
+}

--- a/Client/States/GameStateInGameplay.cpp
+++ b/Client/States/GameStateInGameplay.cpp
@@ -29,9 +29,6 @@ InGameplay::~InGameplay() {
 }
 
 void InGameplay::OnEnter() {
-	std::cout << "GAME LOADED\n";
-	//g = new TutorialGame();
-
 	physics = new PhysicsSystem(*world);
 
 	forceMagnitude = 10.0f;
@@ -56,11 +53,13 @@ int InGameplay::ExitType() {
 }
 
 void InGameplay::Update(float dt) {
+
 	Debug::Print("PRESS L TO END GAME", Vector2(10, 20));
-	if (!inSelectionMode) {
-		world->GetMainCamera()->UpdateCamera(dt);
-	}
+	Window::GetWindow()->ShowOSPointer(false);
+	Window::GetWindow()->LockMouseToWindow(true);
+	world->GetMainCamera()->UpdateCamera(dt);
 	if (lockedObject != nullptr) {
+		
 		Vector3 objPos = lockedObject->GetTransform().GetPosition();
 		Vector3 camPos = objPos + lockedOffset;
 
@@ -75,42 +74,6 @@ void InGameplay::Update(float dt) {
 		world->GetMainCamera()->SetPitch(angles.x);
 		world->GetMainCamera()->SetYaw(angles.y);
 	}
-
-	UpdateKeys();
-
-	if (useGravity) {
-		Debug::Print("(G)ravity on", Vector2(5, 95), Debug::RED);
-	}
-	else {
-		Debug::Print("(G)ravity off", Vector2(5, 95), Debug::RED);
-	}
-
-	RayCollision closestCollision;
-	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::K) && selectionObject) {
-		Vector3 rayPos;
-		Vector3 rayDir;
-
-		rayDir = selectionObject->GetTransform().GetOrientation() * Vector3(0, 0, -1);
-
-		rayPos = selectionObject->GetTransform().GetPosition();
-
-		Ray r = Ray(rayPos, rayDir);
-
-		if (world->Raycast(r, closestCollision, true, selectionObject)) {
-			if (objClosest) {
-				objClosest->GetRenderObject()->SetColour(Vector4(1, 1, 1, 1));
-			}
-			objClosest = (GameObject*)closestCollision.node;
-
-			objClosest->GetRenderObject()->SetColour(Vector4(1, 0, 1, 1));
-		}
-	}
-
-	Debug::DrawLine(Vector3(), Vector3(0, 100, 0), Vector4(1, 0, 0, 1));
-
-	SelectObject();
-	MoveSelectedObject();
-
 	world->UpdateWorld(dt);
 	renderer->Update(dt);
 	physics->Update(dt);
@@ -139,106 +102,10 @@ void InGameplay::InitialiseAssets() {
 void InGameplay::UpdateKeys() {
 	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::F1)) {
 		InitWorld(); //We can reset the simulation at any time with F1
-		selectionObject = nullptr;
 	}
 
 	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::F2)) {
 		InitCamera(); //F2 will reset the camera to a specific default place
-	}
-
-	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::G)) {
-		useGravity = !useGravity; //Toggle gravity!
-		physics->UseGravity(useGravity);
-	}
-	//Running certain physics updates in a consistent order might cause some
-	//bias in the calculations - the same objects might keep 'winning' the constraint
-	//allowing the other one to stretch too much etc. Shuffling the order so that it
-	//is random every frame can help reduce such bias.
-	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::F9)) {
-		world->ShuffleConstraints(true);
-	}
-	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::F10)) {
-		world->ShuffleConstraints(false);
-	}
-
-	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::F7)) {
-		world->ShuffleObjects(true);
-	}
-	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::F8)) {
-		world->ShuffleObjects(false);
-	}
-
-	if (lockedObject) {
-		LockedObjectMovement();
-	}
-	else {
-		DebugObjectMovement();
-	}
-}
-
-void InGameplay::LockedObjectMovement() {
-	Matrix4 view = world->GetMainCamera()->BuildViewMatrix();
-	Matrix4 camWorld = view.Inverse();
-
-	Vector3 rightAxis = Vector3(camWorld.GetColumn(0)); //view is inverse of model!
-
-	//forward is more tricky -  camera forward is 'into' the screen...
-	//so we can take a guess, and use the cross of straight up, and
-	//the right axis, to hopefully get a vector that's good enough!
-
-	Vector3 fwdAxis = Vector3::Cross(Vector3(0, 1, 0), rightAxis);
-	fwdAxis.y = 0.0f;
-	fwdAxis.Normalise();
-
-
-	if (Window::GetKeyboard()->KeyDown(KeyboardKeys::UP)) {
-		selectionObject->GetPhysicsObject()->AddForce(fwdAxis);
-	}
-
-	if (Window::GetKeyboard()->KeyDown(KeyboardKeys::DOWN)) {
-		selectionObject->GetPhysicsObject()->AddForce(-fwdAxis);
-	}
-
-	if (Window::GetKeyboard()->KeyDown(KeyboardKeys::NEXT)) {
-		selectionObject->GetPhysicsObject()->AddForce(Vector3(0, -10, 0));
-	}
-}
-
-void InGameplay::DebugObjectMovement() {
-	//If we've selected an object, we can manipulate it with some key presses
-	if (inSelectionMode && selectionObject) {
-		//Twist the selected object!
-		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::LEFT)) {
-			selectionObject->GetPhysicsObject()->AddTorque(Vector3(-10, 0, 0));
-		}
-
-		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::RIGHT)) {
-			selectionObject->GetPhysicsObject()->AddTorque(Vector3(10, 0, 0));
-		}
-
-		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::NUM7)) {
-			selectionObject->GetPhysicsObject()->AddTorque(Vector3(0, 10, 0));
-		}
-
-		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::NUM8)) {
-			selectionObject->GetPhysicsObject()->AddTorque(Vector3(0, -10, 0));
-		}
-
-		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::RIGHT)) {
-			selectionObject->GetPhysicsObject()->AddTorque(Vector3(10, 0, 0));
-		}
-
-		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::UP)) {
-			selectionObject->GetPhysicsObject()->AddForce(Vector3(0, 0, -10));
-		}
-
-		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::DOWN)) {
-			selectionObject->GetPhysicsObject()->AddForce(Vector3(0, 0, 10));
-		}
-
-		if (Window::GetKeyboard()->KeyDown(KeyboardKeys::NUM5)) {
-			selectionObject->GetPhysicsObject()->AddForce(Vector3(0, -10, 0));
-		}
 	}
 }
 
@@ -248,266 +115,9 @@ void InGameplay::InitCamera() {
 	world->GetMainCamera()->SetPitch(-15.0f);
 	world->GetMainCamera()->SetYaw(315.0f);
 	world->GetMainCamera()->SetPosition(Vector3(-60, 40, 60));
-	lockedObject = nullptr;
 }
 
 void InGameplay::InitWorld() {
 	world->ClearAndErase();
 	physics->Clear();
-
-	InitMixedGridWorld(15, 15, 3.5f, 3.5f);
-
-	InitGameExamples();
-	InitDefaultFloor();
-}
-
-GameObject* InGameplay::AddFloorToWorld(const Vector3& position) {
-	GameObject* floor = new GameObject();
-
-	Vector3 floorSize = Vector3(200, 2, 200);
-	AABBVolume* volume = new AABBVolume(floorSize);
-	floor->SetBoundingVolume((CollisionVolume*)volume);
-	floor->GetTransform()
-		.SetScale(floorSize * 2)
-		.SetPosition(position);
-
-	floor->SetRenderObject(new RenderObject(&floor->GetTransform(), cubeMesh, basicTex, basicShader));
-	floor->SetPhysicsObject(new PhysicsObject(&floor->GetTransform(), floor->GetBoundingVolume()));
-
-	floor->GetPhysicsObject()->SetInverseMass(0);
-	floor->GetPhysicsObject()->InitCubeInertia();
-
-	world->AddGameObject(floor);
-
-	return floor;
-}
-
-GameObject* InGameplay::AddSphereToWorld(const Vector3& position, float radius, float inverseMass) {
-	GameObject* sphere = new GameObject();
-	//Change to test
-
-	Vector3 sphereSize = Vector3(radius, radius, radius);
-	SphereVolume* volume = new SphereVolume(radius);
-	sphere->SetBoundingVolume((CollisionVolume*)volume);
-
-	sphere->GetTransform()
-		.SetScale(sphereSize)
-		.SetPosition(position);
-
-	sphere->SetRenderObject(new RenderObject(&sphere->GetTransform(), sphereMesh, basicTex, basicShader));
-	sphere->SetPhysicsObject(new PhysicsObject(&sphere->GetTransform(), sphere->GetBoundingVolume()));
-
-	sphere->GetPhysicsObject()->SetInverseMass(inverseMass);
-	sphere->GetPhysicsObject()->InitSphereInertia();
-
-	world->AddGameObject(sphere);
-
-	return sphere;
-}
-
-GameObject* InGameplay::AddCubeToWorld(const Vector3& position, Vector3 dimensions, float inverseMass) {
-	GameObject* cube = new GameObject();
-
-	AABBVolume* volume = new AABBVolume(dimensions);
-	cube->SetBoundingVolume((CollisionVolume*)volume);
-
-	cube->GetTransform()
-		.SetPosition(position)
-		.SetScale(dimensions * 2);
-
-	cube->SetRenderObject(new RenderObject(&cube->GetTransform(), cubeMesh, basicTex, basicShader));
-	cube->SetPhysicsObject(new PhysicsObject(&cube->GetTransform(), cube->GetBoundingVolume()));
-
-	cube->GetPhysicsObject()->SetInverseMass(inverseMass);
-	cube->GetPhysicsObject()->InitCubeInertia();
-
-	world->AddGameObject(cube);
-
-	return cube;
-}
-
-GameObject* InGameplay::AddPlayerToWorld(const Vector3& position) {
-	float meshSize = 1.0f;
-	float inverseMass = 0.5f;
-
-	GameObject* character = new GameObject();
-	SphereVolume* volume = new SphereVolume(1.0f);
-
-	character->SetBoundingVolume((CollisionVolume*)volume);
-
-	character->GetTransform()
-		.SetScale(Vector3(meshSize, meshSize, meshSize))
-		.SetPosition(position);
-
-	character->SetRenderObject(new RenderObject(&character->GetTransform(), charMesh, nullptr, basicShader));
-	character->SetPhysicsObject(new PhysicsObject(&character->GetTransform(), character->GetBoundingVolume()));
-
-	character->GetPhysicsObject()->SetInverseMass(inverseMass);
-	character->GetPhysicsObject()->InitSphereInertia();
-
-	world->AddGameObject(character);
-
-	return character;
-}
-
-GameObject* InGameplay::AddEnemyToWorld(const Vector3& position) {
-	float meshSize = 3.0f;
-	float inverseMass = 0.5f;
-
-	GameObject* character = new GameObject();
-
-	AABBVolume* volume = new AABBVolume(Vector3(0.3f, 0.9f, 0.3f) * meshSize);
-	character->SetBoundingVolume((CollisionVolume*)volume);
-
-	character->GetTransform()
-		.SetScale(Vector3(meshSize, meshSize, meshSize))
-		.SetPosition(position);
-
-	character->SetRenderObject(new RenderObject(&character->GetTransform(), enemyMesh, nullptr, basicShader));
-	character->SetPhysicsObject(new PhysicsObject(&character->GetTransform(), character->GetBoundingVolume()));
-
-	character->GetPhysicsObject()->SetInverseMass(inverseMass);
-	character->GetPhysicsObject()->InitSphereInertia();
-
-	world->AddGameObject(character);
-
-	return character;
-}
-
-GameObject* InGameplay::AddBonusToWorld(const Vector3& position) {
-	GameObject* apple = new GameObject();
-
-	SphereVolume* volume = new SphereVolume(0.5f);
-	apple->SetBoundingVolume((CollisionVolume*)volume);
-	apple->GetTransform()
-		.SetScale(Vector3(2, 2, 2))
-		.SetPosition(position);
-
-	apple->SetRenderObject(new RenderObject(&apple->GetTransform(), bonusMesh, nullptr, basicShader));
-	apple->SetPhysicsObject(new PhysicsObject(&apple->GetTransform(), apple->GetBoundingVolume()));
-
-	apple->GetPhysicsObject()->SetInverseMass(1.0f);
-	apple->GetPhysicsObject()->InitSphereInertia();
-
-	world->AddGameObject(apple);
-
-	return apple;
-}
-
-void InGameplay::InitDefaultFloor() {
-	AddFloorToWorld(Vector3(0, -20, 0));
-}
-
-void InGameplay::InitGameExamples() {
-	AddPlayerToWorld(Vector3(0, 5, 0));
-	AddEnemyToWorld(Vector3(5, 5, 0));
-	AddBonusToWorld(Vector3(10, 5, 0));
-}
-
-void InGameplay::InitSphereGridWorld(int numRows, int numCols, float rowSpacing, float colSpacing, float radius) {
-	for (int x = 0; x < numCols; ++x) {
-		for (int z = 0; z < numRows; ++z) {
-			Vector3 position = Vector3(x * colSpacing, 10.0f, z * rowSpacing);
-			AddSphereToWorld(position, radius, 1.0f);
-		}
-	}
-	AddFloorToWorld(Vector3(0, -2, 0));
-}
-
-void InGameplay::InitMixedGridWorld(int numRows, int numCols, float rowSpacing, float colSpacing) {
-	float sphereRadius = 1.0f;
-	Vector3 cubeDims = Vector3(1, 1, 1);
-
-	for (int x = 0; x < numCols; ++x) {
-		for (int z = 0; z < numRows; ++z) {
-			Vector3 position = Vector3(x * colSpacing, 10.0f, z * rowSpacing);
-
-			if (rand() % 2) {
-				AddCubeToWorld(position, cubeDims);
-			}
-			else {
-				AddSphereToWorld(position, sphereRadius);
-			}
-		}
-	}
-}
-
-void InGameplay::InitCubeGridWorld(int numRows, int numCols, float rowSpacing, float colSpacing, const Vector3& cubeDims) {
-	for (int x = 1; x < numCols + 1; ++x) {
-		for (int z = 1; z < numRows + 1; ++z) {
-			Vector3 position = Vector3(x * colSpacing, 10.0f, z * rowSpacing);
-			AddCubeToWorld(position, cubeDims, 1.0f);
-		}
-	}
-}
-
-bool InGameplay::SelectObject() {
-	if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::Q)) {
-		inSelectionMode = !inSelectionMode;
-		if (inSelectionMode) {
-			Window::GetWindow()->ShowOSPointer(true);
-			Window::GetWindow()->LockMouseToWindow(false);
-		}
-		else {
-			Window::GetWindow()->ShowOSPointer(false);
-			Window::GetWindow()->LockMouseToWindow(true);
-		}
-	}
-	if (inSelectionMode) {
-		Debug::Print("Press Q to change to camera mode!", Vector2(5, 85));
-
-		if (Window::GetMouse()->ButtonDown(NCL::MouseButtons::LEFT)) {
-			if (selectionObject) {	//set colour to deselected;
-				selectionObject->GetRenderObject()->SetColour(Vector4(1, 1, 1, 1));
-				selectionObject = nullptr;
-			}
-
-			Ray ray = CollisionDetection::BuildRayFromMouse(*world->GetMainCamera());
-
-			RayCollision closestCollision;
-			if (world->Raycast(ray, closestCollision, true)) {
-				selectionObject = (GameObject*)closestCollision.node;
-
-				selectionObject->GetRenderObject()->SetColour(Vector4(0, 1, 0, 1));
-				return true;
-			}
-			else {
-				return false;
-			}
-		}
-		if (Window::GetKeyboard()->KeyPressed(NCL::KeyboardKeys::L)) {
-			if (selectionObject) {
-				if (lockedObject == selectionObject) {
-					lockedObject = nullptr;
-				}
-				else {
-					lockedObject = selectionObject;
-				}
-			}
-		}
-	}
-	else {
-		Debug::Print("Press Q to change to select mode!", Vector2(5, 85));
-	}
-	return false;
-}
-
-void InGameplay::MoveSelectedObject() {
-	Debug::Print("Click Force:" + std::to_string(forceMagnitude), Vector2(5, 90));
-	forceMagnitude += Window::GetMouse()->GetWheelMovement() * 100.0f;
-
-	if (!selectionObject) {
-		return;//we haven't selected anything!
-	}
-	//Push the selected object!
-	if (Window::GetMouse()->ButtonPressed(NCL::MouseButtons::RIGHT)) {
-		Ray ray = CollisionDetection::BuildRayFromMouse(*world->GetMainCamera());
-
-		RayCollision closestCollision;
-		if (world->Raycast(ray, closestCollision, true)) {
-			if (closestCollision.node == selectionObject) {
-				selectionObject->GetPhysicsObject()->AddForceAtPosition(ray.GetDirection() * forceMagnitude, closestCollision.collidedAt);
-			}
-		}
-	}
 }

--- a/Client/States/GameStateInGameplay.h
+++ b/Client/States/GameStateInGameplay.h
@@ -34,27 +34,6 @@ namespace NCL {
 
 			void InitWorld();
 
-			void InitGameExamples();
-
-			void InitSphereGridWorld(int numRows, int numCols, float rowSpacing, float colSpacing, float radius);
-			void InitMixedGridWorld(int numRows, int numCols, float rowSpacing, float colSpacing);
-			void InitCubeGridWorld(int numRows, int numCols, float rowSpacing, float colSpacing, const Vector3& cubeDims);
-
-			void InitDefaultFloor();
-
-			bool SelectObject();
-			void MoveSelectedObject();
-			void DebugObjectMovement();
-			void LockedObjectMovement();
-
-			GameObject* AddFloorToWorld(const Vector3& position);
-			GameObject* AddSphereToWorld(const Vector3& position, float radius, float inverseMass = 10.0f);
-			GameObject* AddCubeToWorld(const Vector3& position, Vector3 dimensions, float inverseMass = 10.0f);
-
-			GameObject* AddPlayerToWorld(const Vector3& position);
-			GameObject* AddEnemyToWorld(const Vector3& position);
-			GameObject* AddBonusToWorld(const Vector3& position);
-
 
 #ifdef USEVULKAN
 			GameTechVulkanRenderer* renderer;

--- a/Client/States/GameStateInGameplay.h
+++ b/Client/States/GameStateInGameplay.h
@@ -1,0 +1,96 @@
+#pragma once
+#include "State.h"
+#include <iostream>
+#include "Renderer.h"
+#include "PhysicsSystem.h"
+#include "GameWorld.h"
+namespace NCL {
+	namespace CSC8503 {
+		enum ExitStates {
+			Invalid = 0,
+			Win = 1,
+			Loss = 2,
+			Other = 3
+		};
+		class InGameplay : public State
+		{
+		public:
+			InGameplay(GameTechRenderer* rendererRef, GameWorld* gameWorldRef);
+			~InGameplay();
+			void Update(float dt);
+
+			void OnEnter();
+			void OnExit();
+
+			int ExitType();
+
+
+		protected:
+
+			void InitialiseAssets();
+
+			void InitCamera();
+			void UpdateKeys();
+
+			void InitWorld();
+
+			void InitGameExamples();
+
+			void InitSphereGridWorld(int numRows, int numCols, float rowSpacing, float colSpacing, float radius);
+			void InitMixedGridWorld(int numRows, int numCols, float rowSpacing, float colSpacing);
+			void InitCubeGridWorld(int numRows, int numCols, float rowSpacing, float colSpacing, const Vector3& cubeDims);
+
+			void InitDefaultFloor();
+
+			bool SelectObject();
+			void MoveSelectedObject();
+			void DebugObjectMovement();
+			void LockedObjectMovement();
+
+			GameObject* AddFloorToWorld(const Vector3& position);
+			GameObject* AddSphereToWorld(const Vector3& position, float radius, float inverseMass = 10.0f);
+			GameObject* AddCubeToWorld(const Vector3& position, Vector3 dimensions, float inverseMass = 10.0f);
+
+			GameObject* AddPlayerToWorld(const Vector3& position);
+			GameObject* AddEnemyToWorld(const Vector3& position);
+			GameObject* AddBonusToWorld(const Vector3& position);
+
+
+#ifdef USEVULKAN
+			GameTechVulkanRenderer* renderer;
+#else
+			GameTechRenderer* renderer;
+#endif
+			PhysicsSystem* physics;
+			GameWorld* world;
+
+			bool useGravity;
+			bool inSelectionMode;
+
+			float		forceMagnitude;
+
+			GameObject* selectionObject = nullptr;
+
+			MeshGeometry* capsuleMesh = nullptr;
+			MeshGeometry* cubeMesh = nullptr;
+			MeshGeometry* sphereMesh = nullptr;
+
+			TextureBase* basicTex = nullptr;
+			ShaderBase* basicShader = nullptr;
+
+			//Coursework Meshes
+			MeshGeometry* charMesh = nullptr;
+			MeshGeometry* enemyMesh = nullptr;
+			MeshGeometry* bonusMesh = nullptr;
+
+			//Coursework Additional functionality	
+			GameObject* lockedObject = nullptr;
+			Vector3 lockedOffset = Vector3(0, 14, 20);
+			void LockCameraToObject(GameObject* o) {
+				lockedObject = o;
+			}
+
+			GameObject* objClosest = nullptr;
+		};
+	}
+}

--- a/Client/States/GameStateInactive.cpp
+++ b/Client/States/GameStateInactive.cpp
@@ -1,0 +1,27 @@
+#include "GameStateInactive.h"
+using namespace NCL;
+using namespace CSC8503;
+
+Inactive::Inactive(GameTechRenderer* rendererRef, GameWorld* gameWorldRef) : State() {
+	renderer = rendererRef;
+	world = gameWorldRef;
+}
+
+Inactive::~Inactive() {
+
+}
+
+void Inactive::Update(float dt) {
+	Debug::Print("INACTIVE MENU", Vector2(10, 10));
+	Debug::Print("PRESS SPACE TO MENU", Vector2(10, 20));
+	renderer->Render();
+	Debug::UpdateRenderables(dt);
+}
+
+void Inactive::OnEnter() {
+}
+
+void Inactive::OnExit() {
+	world->ClearAndErase();
+	renderer->Render();
+}

--- a/Client/States/GameStateInactive.h
+++ b/Client/States/GameStateInactive.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "State.h"
+#include <iostream>
+#include "./../Client/Renderer.h"
+#include "PhysicsSystem.h"
+#include "GameWorld.h"
+namespace NCL {
+	namespace CSC8503 {
+		class Inactive : public State
+		{
+		public:
+			Inactive(GameTechRenderer* rendererRef, GameWorld* gameWorldRef);
+			~Inactive();
+			void Update(float dt);
+
+			void OnEnter();
+			void OnExit();
+		protected:
+#ifdef USEVULKAN
+			GameTechVulkanRenderer* renderer;
+#else
+			GameTechRenderer* renderer;
+#endif
+			PhysicsSystem* physics;
+			GameWorld* world;
+		};
+	}
+}

--- a/Client/States/GameStateLoading.cpp
+++ b/Client/States/GameStateLoading.cpp
@@ -1,0 +1,28 @@
+#include "GameStateLoading.h"
+using namespace NCL;
+using namespace CSC8503;
+
+Loading::Loading(GameTechRenderer* rendererRef, GameWorld* gameWorldRef) : State() {
+	renderer = rendererRef;
+	world = gameWorldRef;
+}
+
+Loading::~Loading() {
+
+}
+
+void Loading::Update(float dt) {
+	Debug::Print("LOADING", Vector2(10, 10));
+	Debug::Print("PRESS SPACE TO GAMEPLAY", Vector2(10, 20));
+	Debug::Print("PRESS L TO MENU", Vector2(10, 30));
+	renderer->Render();
+	Debug::UpdateRenderables(dt);
+}
+void Loading::OnEnter() {
+	std::cout << "LOADING\n";
+}
+
+void Loading::OnExit() {
+	world->ClearAndErase();
+	renderer->Render();
+}

--- a/Client/States/GameStateLoading.h
+++ b/Client/States/GameStateLoading.h
@@ -6,11 +6,11 @@
 #include "GameWorld.h"
 namespace NCL {
 	namespace CSC8503 {
-		class Inactive : public State
+		class Loading : public State
 		{
 		public:
-			Inactive(GameTechRenderer* rendererRef, GameWorld* gameWorldRef);
-			~Inactive();
+			Loading(GameTechRenderer* rendererRef, GameWorld* gameWorldRef);
+			~Loading();
 			void Update(float dt);
 
 			void OnEnter();

--- a/Client/States/GameStateMenu.cpp
+++ b/Client/States/GameStateMenu.cpp
@@ -1,0 +1,29 @@
+#include "GameStateMenu.h"
+using namespace NCL;
+using namespace CSC8503;
+
+Menu::Menu(GameTechRenderer* rendererRef, GameWorld* gameWorldRef) : State()
+{
+	renderer = rendererRef;
+	world = gameWorldRef;
+}
+
+Menu::~Menu() {
+
+}
+
+void Menu::Update(float dt) {
+
+	Debug::Print("MENU", Vector2(10, 10));
+	Debug::Print("PRESS SPACE TO LOADING", Vector2(10, 20));
+	renderer->Render();
+	Debug::UpdateRenderables(dt);
+}
+void Menu::OnEnter() {
+	std::cout << "MENU\n";
+}
+
+void Menu::OnExit() {
+	world->ClearAndErase();
+	renderer->Render();
+}

--- a/Client/States/GameStateMenu.h
+++ b/Client/States/GameStateMenu.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "State.h"
+#include <iostream>
+#include "Renderer.h"
+#include "PhysicsSystem.h"
+#include "GameWorld.h"
+namespace NCL {
+	namespace CSC8503 {
+		class Menu : public State
+		{
+		public:
+			Menu(GameTechRenderer* rendererRef, GameWorld* gameWorldRef);
+			~Menu();
+			void Update(float dt);
+
+			void OnEnter();
+			void OnExit();
+		protected:
+#ifdef USEVULKAN
+			GameTechVulkanRenderer* renderer;
+#else
+			GameTechRenderer* renderer;
+#endif
+			PhysicsSystem* physics;
+			GameWorld* world;
+		};
+	}
+}

--- a/Client/main.cpp
+++ b/Client/main.cpp
@@ -13,17 +13,13 @@
 
 #include "TutorialGame.h"
 
+#include "ClientGameStateMachine.h"
 using namespace NCL;
 using namespace CSC8503;
 
 
-int main() {
-    Window*w = Window::CreateGameWindow("CSC8503 Game technology!", 1280, 720);
-
-    if (!w->HasInitialised()) {
-        return -1;
-    }
-
+void RunTutorialGame(Window* w)
+{
     w->ShowOSPointer(false);
     w->LockMouseToWindow(true);
 
@@ -51,4 +47,44 @@ int main() {
         g->UpdateGame(dt);
     }
     Window::DestroyGameWindow();
+}
+
+void RunClientGameStateMachine(Window* w)
+{
+    w->GetTimer()->GetTimeDeltaSeconds(); 
+    ClientGameStateMachine* client = new ClientGameStateMachine;
+
+    while (w->UpdateWindow() && !Window::GetKeyboard()->KeyDown(KeyboardKeys::ESCAPE)) {
+        float dt = w->GetTimer()->GetTimeDeltaSeconds();
+        if (dt > 0.1f) {
+            std::cout << "Skipping large time delta" << std::endl;
+            continue;
+        }
+        if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::PRIOR)) {
+            w->ShowConsole(true);
+        }
+        if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::NEXT)) {
+            w->ShowConsole(false);
+        }
+        if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::T)) {
+            w->SetWindowPosition(0, 0);
+        }
+
+        w->SetTitle("Gametech frame time:" + std::to_string(1000.0f * dt));
+        client->Update(dt);
+    }
+    Window::DestroyGameWindow();
+}
+
+
+int main() {
+    Window*w = Window::CreateGameWindow("CSC8503 Game technology!", 1280, 720);
+
+    if (!w->HasInitialised()) {
+        return -1;
+    }
+
+    //RunTutorialGame(w);
+    RunClientGameStateMachine(w);
+
 }

--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 project(server)
 
-add_executable(server Server.cpp main.cpp "States/GameStateBusy.h" "States/GameStateBusy.cpp" "States/GameStateRunning.cpp" "States/GameStateRunning.h" "States/GameStateWaitingPlayers.cpp" "States/GameStateWaitingPlayers.h")
-target_include_directories(server PUBLIC ../NCLCoreClasses ../CSC8503CoreClasses ../OpenGLRendering ../Replicated ./)
+add_executable(server 
+Server.cpp 
+main.cpp 
+"States/GameStateBusy.cpp" 
+"States/GameStateRunning.cpp" 
+"States/GameStateWaitingPlayers.cpp" 
+"ServerGameStateMachine.cpp" )
+target_include_directories(server PUBLIC ../NCLCoreClasses ../CSC8503CoreClasses ../OpenGLRendering ../Replicated ./ ./States)
 target_link_libraries(server PUBLIC NCLCoreClasses CSC8503CoreClasses OpenGLRendering replicated)

--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 project(server)
 
-add_executable(server Server.cpp main.cpp "States/GameStateBusy.h" "States/GameStateBusy.cpp" "States/GameStateRunning.cpp" "States/GameStateRunning.h")
+add_executable(server Server.cpp main.cpp "States/GameStateBusy.h" "States/GameStateBusy.cpp" "States/GameStateRunning.cpp" "States/GameStateRunning.h" "States/GameStateWaitingPlayers.cpp" "States/GameStateWaitingPlayers.h")
 target_include_directories(server PUBLIC ../NCLCoreClasses ../CSC8503CoreClasses ../OpenGLRendering ../Replicated ./)
 target_link_libraries(server PUBLIC NCLCoreClasses CSC8503CoreClasses OpenGLRendering replicated)

--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 project(server)
 
-add_executable(server Server.cpp main.cpp "States/GameStateBusy.h" "States/GameStateBusy.cpp")
+add_executable(server Server.cpp main.cpp "States/GameStateBusy.h" "States/GameStateBusy.cpp" "States/GameStateRunning.cpp" "States/GameStateRunning.h")
 target_include_directories(server PUBLIC ../NCLCoreClasses ../CSC8503CoreClasses ../OpenGLRendering ../Replicated ./)
 target_link_libraries(server PUBLIC NCLCoreClasses CSC8503CoreClasses OpenGLRendering replicated)

--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 project(server)
 
-add_executable(server Server.cpp main.cpp)
+add_executable(server Server.cpp main.cpp "States/GameStateBusy.h" "States/GameStateBusy.cpp")
 target_include_directories(server PUBLIC ../NCLCoreClasses ../CSC8503CoreClasses ../OpenGLRendering ../Replicated ./)
 target_link_libraries(server PUBLIC NCLCoreClasses CSC8503CoreClasses OpenGLRendering replicated)

--- a/Server/ServerGameStateMachine.cpp
+++ b/Server/ServerGameStateMachine.cpp
@@ -1,0 +1,38 @@
+#include "ServerGameStateMachine.h"
+#include "State.h"
+#include "StateTransition.h"
+#include "GameStateBusy.h"
+#include "GameStateWaitingPlayers.h"
+#include "GameStateRunning.h"
+using namespace NCL;
+using namespace CSC8503;
+ServerGameStateMachine::ServerGameStateMachine() : StateMachine()
+{
+	currentServerState = ServerStates::BusyState;
+	InitialiseServerStateMachine();
+}
+
+ServerGameStateMachine::~ServerGameStateMachine()
+{
+}
+
+void ServerGameStateMachine::InitialiseServerStateMachine()
+{
+	Busy* serverBusy = new Busy();
+	WaitingPlayers* serverWaitingPlayers = new WaitingPlayers();
+	Running* serverRunning = new Running();
+
+	StateTransition* busyToWaiting = new StateTransition(serverBusy, serverWaitingPlayers, [&](void)->bool { return currentServerState == ServerStates::WaitingPlayersState; });
+	StateTransition* waitingToBusy = new StateTransition(serverWaitingPlayers, serverBusy, [&](void)->bool { return currentServerState == ServerStates::BusyState; });
+	StateTransition* waitingToRunning = new StateTransition(serverWaitingPlayers, serverRunning, [&](void)->bool { return currentServerState == ServerStates::RunningState; });
+	StateTransition* runningToWaiting = new StateTransition(serverRunning, serverWaitingPlayers, [&](void)->bool { return currentServerState == ServerStates::WaitingPlayersState; });
+
+	this->AddState(serverBusy);
+	this->AddState(serverWaitingPlayers);
+	this->AddState(serverRunning);
+
+	this->AddTransition(busyToWaiting);
+	this->AddTransition(waitingToBusy);
+	this->AddTransition(waitingToRunning);
+	this->AddTransition(runningToWaiting);
+}

--- a/Server/ServerGameStateMachine.h
+++ b/Server/ServerGameStateMachine.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "StateMachine.h"
+#include <vector>
+namespace NCL {
+	namespace CSC8503 {
+		enum ServerStates {
+			BusyState,
+			WaitingPlayersState,
+			RunningState
+		};
+		class ServerGameStateMachine : public StateMachine {
+		public:
+			ServerGameStateMachine();
+			virtual ~ServerGameStateMachine();
+			void SetAvailableLevels(std::vector<State*> levels)
+			{
+				availableLevels = levels;
+			}
+		protected:
+			ServerStates currentServerState;
+			std::vector<State*> availableLevels;
+			void InitialiseServerStateMachine();
+		};
+	}
+}

--- a/Server/States/GameStateBusy.cpp
+++ b/Server/States/GameStateBusy.cpp
@@ -1,0 +1,18 @@
+#include "GameStateBusy.h"
+using namespace NCL;
+using namespace CSC8503;
+
+Busy::Busy() : State()
+{
+
+}
+
+Busy::~Busy()
+{
+
+}
+
+void Busy::Update(float dt)
+{
+
+}

--- a/Server/States/GameStateBusy.h
+++ b/Server/States/GameStateBusy.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "State.h"
+#include <iostream>
+
+namespace NCL {
+	namespace CSC8503 {
+		class Busy : public State
+		{
+		public:
+			Busy();
+			~Busy();
+			void Update(float dt);
+
+			void OnEnter();
+			void OnExit();
+		protected:
+
+		};
+	}
+}

--- a/Server/States/GameStateBusy.h
+++ b/Server/States/GameStateBusy.h
@@ -11,8 +11,8 @@ namespace NCL {
 			~Busy();
 			void Update(float dt);
 
-			void OnEnter();
-			void OnExit();
+			void OnEnter() {}
+			void OnExit() {}
 		protected:
 
 		};

--- a/Server/States/GameStateRunning.cpp
+++ b/Server/States/GameStateRunning.cpp
@@ -1,0 +1,18 @@
+#include "GameStateRunning.h"
+using namespace NCL;
+using namespace CSC8503;
+
+Running::Running() : State()
+{
+
+}
+
+Running::~Running()
+{
+
+}
+
+void Running::Update(float dt)
+{
+
+}

--- a/Server/States/GameStateRunning.h
+++ b/Server/States/GameStateRunning.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "State.h"
+#include <iostream>
+namespace NCL {
+	namespace CSC8503 {
+		class Running : public State
+		{
+		public:
+			Running();
+			~Running();
+			void Update(float dt);
+
+			void OnEnter() { std::cout << "On Enter"; }
+			void OnExit() { std::cout << "On Exit"; }
+		protected:
+
+		};
+	}
+}

--- a/Server/States/GameStateWaitingPlayers.cpp
+++ b/Server/States/GameStateWaitingPlayers.cpp
@@ -1,0 +1,18 @@
+#include "GameStateWaitingPlayers.h"
+using namespace NCL;
+using namespace CSC8503;
+
+WaitingPlayers::WaitingPlayers() : State()
+{
+
+}
+
+WaitingPlayers::~WaitingPlayers()
+{
+
+}
+
+void WaitingPlayers::Update(float dt)
+{
+
+}

--- a/Server/States/GameStateWaitingPlayers.h
+++ b/Server/States/GameStateWaitingPlayers.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "State.h"
+#include <iostream>
+
+namespace NCL {
+	namespace CSC8503 {
+		class WaitingPlayers : public State
+		{
+		public:
+			WaitingPlayers();
+			~WaitingPlayers();
+			void Update(float dt);
+
+			void OnEnter() { std::cout << "On Enter"; }
+			void OnExit() { std::cout << "On Exit"; }
+		protected:
+
+		};
+	}
+}


### PR DESCRIPTION
Porting over changes from the old GameState brach (branch was affected by **CURSE OF BLINDNESS**, **CURSE OF CMAKE**).
Just going to put the old pull request description here:

Basic frame for the state machines for the client and server.
Server has 3 states:

Busy (loading shit, base state)
Waiting (loaded shit, no players)
Running (loaded shit, players)
Client has 5:

Inactive (base state)
Loading (load shit, happens between most transitions between the below states)
Menu
InGameplay (the game)
You can change the state of each by using SetServerState/SetClientState, and what state is updated is automatically set.
Also Joe told me to change the Update in the base state class so if any state machine in the future doesn't work please talk to him.
There is also a vector for multiple states which are meant to be levels but it isn't used anywhere anyways because idk how we're gonna handle that.

===NEW===
Client state machine has been updated to function in game.
Pretty much all the contents of Tutorial game have been copied over into it.
All states pertaining to the client now require a reference to a gameworld and renderer upon creation.
The creation of these two are handled within the initialisation of the client state machine.
The client state machine now displays what state the machine is in on gamescreen, with what button to press to switch states.
InGame state now has a method to specify an exit state, with ExitState::Invalid preventing the game from ending.
I've also moved the states to the client folder from the 8053CoreClasses folder.

==NOTE==
Client main now no longer makes a tutorial game.