### PR TITLE
Added level building over the network

### DIFF
--- a/CSC8503CoreClasses/GameWorld.h
+++ b/CSC8503CoreClasses/GameWorld.h
@@ -78,7 +78,7 @@ namespace NCL {
                 return networkObjects.end();
             }
 
-            vector<NetworkObject *> &GetNetworkObjects();
+            std::vector<NetworkObject *> &GetNetworkObjects();
 
         protected:
             std::vector<GameObject*> gameObjects;

--- a/CSC8503CoreClasses/PhysicsObject.h
+++ b/CSC8503CoreClasses/PhysicsObject.h
@@ -14,13 +14,13 @@ namespace NCL {
             float linearDampingHorizontal = 0.995f;
             float angularDamping = 0.995f;
             PhysicsMaterial() {
-		e = 0.8f
+		        e = 0.8f;
                 linearDampingVertical = 0.995f;
                 linearDampingHorizontal = 0.995f;
                 angularDamping = 0.995f;
             }
             PhysicsMaterial(float coeffOfRest, float linV, float linH, float ang) {
-		e = coeffOfRest;
+		        e = coeffOfRest;
                 linearDampingVertical = linV;
                 linearDampingHorizontal = linH;
                 angularDamping = ang;

--- a/Server/States/RunningState.cpp
+++ b/Server/States/RunningState.cpp
@@ -74,6 +74,7 @@ void RunningState::Update(float dt) {
 }
 
 void RunningState::LoadLevel() {
+    BuildLevel("Level1");
     CreatePlayers();
 }
 
@@ -121,4 +122,21 @@ void RunningState::UpdatePlayerMovement(GameObject* player, const InputPacket& i
     player->GetTransform().SetOrientation(inputInfo.playerRotation);
     player->GetTransform().SetPosition(player->GetTransform().GetPosition()
                                        + Vector3(inputInfo.playerDirection.x, 0, inputInfo.playerDirection.y) * 2.0f);
+}
+
+void RunningState::BuildLevel(const std::string &levelName)
+{
+    std::cout << "Level: " << levelName << " being built\n";
+    levelReader = new LevelReader();
+    if (!levelReader->HasReadLevel(levelName + ".json"))
+    {
+        std::cerr << "No file available. Check " + Assets::LEVELDIR << std::endl;
+        return;
+    }
+    auto plist = levelReader->GetPrimitiveList();
+    for(auto x: plist){
+        auto g = new GameObject();
+        replicated->AddBlockToLevel(g, *world, x);
+        g->SetPhysicsObject(new PhysicsObject(&g->GetTransform(), g->GetBoundingVolume()));
+    }
 }

--- a/Server/States/RunningState.cpp
+++ b/Server/States/RunningState.cpp
@@ -137,6 +137,6 @@ void RunningState::BuildLevel(const std::string &levelName)
     for(auto x: plist){
         auto g = new GameObject();
         replicated->AddBlockToLevel(g, *world, x);
-        g->SetPhysicsObject(new PhysicsObject(&g->GetTransform(), g->GetBoundingVolume()));
+        g->SetPhysicsObject(new PhysicsObject(&g->GetTransform(), g->GetBoundingVolume(), new PhysicsMaterial()));
     }
 }

--- a/Server/States/RunningState.h
+++ b/Server/States/RunningState.h
@@ -44,6 +44,8 @@ namespace NCL {
 
             std::unordered_map<int, PlayerInfo> playerInfo;
 
+            LevelReader* levelReader;
+
             float packetTimer;
             int sceneSnapshotId;
 
@@ -52,6 +54,7 @@ namespace NCL {
             std::unordered_map<int, GameObject*> playerObjects;
 
             void LoadLevel();
+            void BuildLevel(const std::string &levelName);
             void CreatePlayers();
 
             void SendWorldToClient();


### PR DESCRIPTION
I made a new function in the Running state (server side) to build a level from a json file. The function goes through each game object in the file and uses the replicated function 'AddBlockToLevel' to add the game object to the level. The AddBlockToLevel function only deals with setting up the collision volume therefore I set the physics object server side.
