### PR TITLE
Fixed Start() not being called on components

### DIFF
--- a/Client/States/GameplayState.cpp
+++ b/Client/States/GameplayState.cpp
@@ -152,6 +152,7 @@ void GameplayState::InitialiseAssets() {
 
 void GameplayState::FinishLoading() {
     networkData->outgoingFunctions.Push(FunctionPacket(Replicated::GameLoaded, nullptr));
+    world->StartWorld();
 }
 
 void GameplayState::InitCamera() {

--- a/Server/States/RunningState.cpp
+++ b/Server/States/RunningState.cpp
@@ -23,6 +23,7 @@ void RunningState::OnEnter() {
     sceneSnapshotId = 0;
     CreateNetworkThread();
     LoadLevel();
+    world->StartWorld();
 
 }
 


### PR DESCRIPTION
Small branch, just:
-Start is now called after all objects are set up, both server side and client side.