### PR TITLE
Fix on collision functions

### DIFF
--- a/CSC8503CoreClasses/GameObject.cpp
+++ b/CSC8503CoreClasses/GameObject.cpp
@@ -10,12 +10,11 @@ GameObject::GameObject(string objectName)	{
     name			= objectName;
     worldID			= -1;
     isActive		= true;
+    hasComponent    = false;
     boundingVolume	= nullptr; // Replicated
     networkObject	= nullptr; // Replicated
     physicsObject	= nullptr; // Server
     renderObject	= nullptr; // Client
-    isPlayer        = false;
-
 }
 
 GameObject::~GameObject()	{

--- a/CSC8503CoreClasses/GameObject.h
+++ b/CSC8503CoreClasses/GameObject.h
@@ -106,23 +106,22 @@ namespace NCL::CSC8503 {
 
         void AddComponent(Component* component) {
             components.push_back(component);
+            SetHasComponent(true);
         }
 
         std::vector<Component*> components;
 
         Transform transform;
 
-        int GetWorldID() const {
-            return worldID;
-        }
+        int GetWorldID() const { return worldID; }
 
         const Tag GetTag() { return tag; }
         void SetTag(Tag t) { tag = t; }
 
-        void DrawCollision();
+        const bool GetHasComponent() { return hasComponent; }
+        void SetHasComponent(bool b) { hasComponent = b; }
 
-        [[nodiscard]] bool GetIsPlayerBool() const { return isPlayer; }
-        void SetIsPlayerBool(bool b) { isPlayer = b;  }
+        void DrawCollision();
 
     protected:
 
@@ -132,7 +131,7 @@ namespace NCL::CSC8503 {
         NetworkObject*		networkObject;
 
         bool		isActive;
-        bool        isPlayer;
+        bool        hasComponent;
         int			worldID;
         std::string	name;
 

--- a/CSC8503CoreClasses/PhysicsObject.cpp
+++ b/CSC8503CoreClasses/PhysicsObject.cpp
@@ -9,6 +9,7 @@ PhysicsObject::PhysicsObject(Transform* parentTransform, const CollisionVolume* 
 	volume		= parentVolume;
     physicsMaterial = physMat;
 	inverseMass = 1.0f;
+    isTrigger = false;
 }
 
 PhysicsObject::~PhysicsObject()	{

--- a/CSC8503CoreClasses/PhysicsObject.h
+++ b/CSC8503CoreClasses/PhysicsObject.h
@@ -138,7 +138,7 @@ namespace NCL {
 			Vector3 inverseInertia;
 			Matrix3 inverseInteriaTensor;
 
-            bool isTrigger = false;
+            bool isTrigger;
 		};
 	}
 }

--- a/CSC8503CoreClasses/PhysicsSystem.cpp
+++ b/CSC8503CoreClasses/PhysicsSystem.cpp
@@ -174,7 +174,11 @@ void PhysicsSystem::UpdateCollisionList() {
 			i->b->OnCollisionBegin(i->a);
 		}
         CollisionDetection::CollisionInfo blank;
-        if(i->a->GetPhysicsObject()->GetIsTriggerVolume() || i->b->GetPhysicsObject()->GetIsTriggerVolume()){
+        if(i->a->GetPhysicsObject()->GetIsTriggerVolume()   ||
+           i->b->GetPhysicsObject()->GetIsTriggerVolume()   ||
+           i->a->GetHasComponent() ||
+           i->b->GetHasComponent() )
+        {
             in.framesLeft = 4;
 
             if(!CollisionDetection::ObjectIntersection(i->a,i->b, blank)){
@@ -258,12 +262,10 @@ void PhysicsSystem::ImpulseResolveCollision(GameObject& a, GameObject& b, Collis
 
     if(a.GetPhysicsObject()->GetIsTriggerVolume())
     {
-        a.DrawCollision();
         return;
     }
     if(b.GetPhysicsObject()->GetIsTriggerVolume())
     {
-        b.DrawCollision();
         return;
     }
 

--- a/Replicated/Components/SwingingObject.cpp
+++ b/Replicated/Components/SwingingObject.cpp
@@ -34,5 +34,5 @@ void SwingingObject::OnCollisionStay(NCL::CSC8503::GameObject *otherObject) {
 
 void SwingingObject::OnCollisionEnd(GameObject *otherObject) {
     Component::OnCollisionEnter(otherObject);
-    std::cout << "player has collided with swinging object\n";
+    std::cout << "player has STOPPED colliding with swinging object\n";
 }

--- a/Replicated/Components/SwingingObject.cpp
+++ b/Replicated/Components/SwingingObject.cpp
@@ -21,3 +21,18 @@ void SwingingObject::CheckTimerState()
     if (timer >= MAX_TIMER) { ascending = false; }
     if (timer <= MIN_TIMER) { ascending = true; }
 }
+
+void SwingingObject::OnCollisionEnter(GameObject *otherObject) {
+    Component::OnCollisionEnter(otherObject);
+    std::cout << "player has collided with swinging object\n";
+}
+
+void SwingingObject::OnCollisionStay(NCL::CSC8503::GameObject *otherObject) {
+    Component::OnCollisionEnter(otherObject);
+    std::cout << "player has collided with swinging object\n";
+}
+
+void SwingingObject::OnCollisionEnd(GameObject *otherObject) {
+    Component::OnCollisionEnter(otherObject);
+    std::cout << "player has collided with swinging object\n";
+}

--- a/Replicated/Components/SwingingObject.h
+++ b/Replicated/Components/SwingingObject.h
@@ -22,6 +22,10 @@ namespace NCL::CSC8503 {
 			CheckTimerState();
 		}
 
+        void OnCollisionEnter(GameObject* otherObject) override;
+        void OnCollisionStay(GameObject* otherObject) override;
+        void OnCollisionEnd(GameObject* otherObject) override;
+
 		void PhysicsUpdate(float dt)override {}
 
 		void CheckTimerState();

--- a/Replicated/TriggerVolumeObject.cpp
+++ b/Replicated/TriggerVolumeObject.cpp
@@ -6,7 +6,7 @@
 
 
 void TriggerVolumeObject::OnCollisionBegin(GameObject *otherObject) {
-    if(otherObject->GetIsPlayerBool()){
+    if(otherObject->GetTag() == Tag::PLAYER){
         switch (triggerType) {
             case TriggerType::Start: // Start volume
                 std::cout << "Start volume\n";
@@ -26,7 +26,7 @@ void TriggerVolumeObject::OnCollisionBegin(GameObject *otherObject) {
 }
 
 void TriggerVolumeObject::OnCollisionEnd(GameObject *otherObject) {
-    if(otherObject->GetIsPlayerBool()){
+    if(otherObject->GetTag() == Tag::PLAYER){
         std::cout << "Collision with player has ended\n";
     }
 }

--- a/Server/States/RunningState.cpp
+++ b/Server/States/RunningState.cpp
@@ -130,7 +130,6 @@ void RunningState::CreatePlayers() {
         player->GetPhysicsObject()->SetInverseMass(2.0f);
         player->GetPhysicsObject()->InitSphereInertia();
         player->GetPhysicsObject()->SetPhysMat(physics->GetPhysMat("Player"));
-        player->SetIsPlayerBool(true);
         player->SetTag(Tag::PLAYER);
 
         //TODO: clean up


### PR DESCRIPTION
Created a bool inside of GameObject.h, hasComponent, to be true if the game object has a component. The use of this bool lies in the physics system where if true then, OnCollisionEnter & OnCollisionEnd are not called continuously.


Removed the following redundant code:
bool isPlayer inside GameObject.h and .cpp, instead I used Matthew's tag system.
