### PR TITLE
Check point system

### DIFF
--- a/CSC8503CoreClasses/GameObject.cpp
+++ b/CSC8503CoreClasses/GameObject.cpp
@@ -6,7 +6,7 @@
 #include "Debug.h"
 using namespace NCL::CSC8503;
 
-GameObject::GameObject(string objectName)	{
+GameObject::GameObject(std::string objectName)	{
     name			= objectName;
     worldID			= -1;
     isActive		= true;

--- a/CSC8503CoreClasses/GameObject.h
+++ b/CSC8503CoreClasses/GameObject.h
@@ -124,12 +124,17 @@ namespace NCL::CSC8503 {
         [[nodiscard]] bool GetIsPlayerBool() const { return isPlayer; }
         void SetIsPlayerBool(bool b) { isPlayer = b;  }
 
+        [[nodiscard]] Vector3 GetCurrentCheckPointPos() const { return checkPointPos; }
+        void SetCurrentCheckPointPos(Vector3 v) { checkPointPos = v;  }
+
     protected:
 
         CollisionVolume*	boundingVolume;
         PhysicsObject*		physicsObject;
         RenderObject*		renderObject;
         NetworkObject*		networkObject;
+
+        Vector3 checkPointPos;
 
         bool		isActive;
         bool        isPlayer;

--- a/CSC8503CoreClasses/PhysicsObject.cpp
+++ b/CSC8503CoreClasses/PhysicsObject.cpp
@@ -45,6 +45,7 @@ void PhysicsObject::AddTorque(const Vector3& addedTorque) {
 void PhysicsObject::ClearForces() {
 	force				= Vector3();
 	torque				= Vector3();
+    linearVelocity      = Vector3();
 }
 
 void PhysicsObject::InitCubeInertia() {

--- a/CSC8503CoreClasses/PhysicsObject.cpp
+++ b/CSC8503CoreClasses/PhysicsObject.cpp
@@ -45,6 +45,9 @@ void PhysicsObject::AddTorque(const Vector3& addedTorque) {
 void PhysicsObject::ClearForces() {
 	force				= Vector3();
 	torque				= Vector3();
+}
+
+void PhysicsObject::ClearVelocity() {
     linearVelocity      = Vector3();
 }
 

--- a/CSC8503CoreClasses/PhysicsObject.h
+++ b/CSC8503CoreClasses/PhysicsObject.h
@@ -68,6 +68,7 @@ namespace NCL {
 
 
 			void ClearForces();
+			void ClearVelocity();
 
 			void SetLinearVelocity(const Vector3& v) {
 				linearVelocity = v;

--- a/CSC8503CoreClasses/PhysicsSystem.cpp
+++ b/CSC8503CoreClasses/PhysicsSystem.cpp
@@ -258,12 +258,10 @@ void PhysicsSystem::ImpulseResolveCollision(GameObject& a, GameObject& b, Collis
 
     if(a.GetPhysicsObject()->GetIsTriggerVolume())
     {
-        a.DrawCollision();
         return;
     }
     if(b.GetPhysicsObject()->GetIsTriggerVolume())
     {
-        b.DrawCollision();
         return;
     }
 

--- a/Client/States/GameplayState.cpp
+++ b/Client/States/GameplayState.cpp
@@ -94,6 +94,14 @@ void GameplayState::Update(float dt) {
     renderer->Render();
     Debug::UpdateRenderables(dt);
 
+    if (Window::GetKeyboard()->KeyPressed(KeyboardKeys::NUM7)) {
+        ResetCameraToForwards();
+    }
+}
+
+void GameplayState::ResetCameraToForwards() {
+    world->GetMainCamera()->SetPitch(0.68f);
+    world->GetMainCamera()->SetYaw(269.43f);
 }
 
 void GameplayState::ReadNetworkFunctions() {

--- a/Client/States/GameplayState.h
+++ b/Client/States/GameplayState.h
@@ -42,6 +42,7 @@ namespace NCL {
             void CreateNetworkThread();
             void InitLevel();
             void InitCanvas();
+            void ResetCameraToForwards();
 
 
 #ifdef USEVULKAN

--- a/Replicated/TriggerVolumeObject.cpp
+++ b/Replicated/TriggerVolumeObject.cpp
@@ -3,19 +3,24 @@
 //
 
 #include "TriggerVolumeObject.h"
+#include "PhysicsObject.h"
 
+using namespace NCL::CSC8503;
 
 void TriggerVolumeObject::OnCollisionBegin(GameObject *otherObject) {
     if(otherObject->GetIsPlayerBool()){
         switch (triggerType) {
-            case TriggerType::Start: // Start volume
+            case TriggerType::Start:
                 std::cout << "Start volume\n";
                 break;
-            case TriggerType::End: // End Volume
+            case TriggerType::End:
                 std::cout << "End volume\n";
                 break;
-            case TriggerType::Death: // Death Volume
-                std::cout << "Death volume\n";
+            case TriggerType::Death:
+                otherObject->GetTransform().SetPosition(otherObject->GetCurrentCheckPointPos());
+                break;
+            case TriggerType::CheckPoint:
+                otherObject->SetCurrentCheckPointPos(this->GetTransform().GetPosition());
                 break;
 
             default:

--- a/Replicated/TriggerVolumeObject.cpp
+++ b/Replicated/TriggerVolumeObject.cpp
@@ -17,6 +17,7 @@ void TriggerVolumeObject::OnCollisionBegin(GameObject *otherObject) {
                 std::cout << "End volume\n";
                 break;
             case TriggerType::Death:
+                otherObject->GetPhysicsObject()->ClearForces();
                 otherObject->GetTransform().SetPosition(otherObject->GetCurrentCheckPointPos());
                 break;
             case TriggerType::CheckPoint:

--- a/Replicated/TriggerVolumeObject.cpp
+++ b/Replicated/TriggerVolumeObject.cpp
@@ -19,6 +19,7 @@ void TriggerVolumeObject::OnCollisionBegin(GameObject *otherObject) {
                 break;
             case TriggerType::Death:
                 otherObject->GetPhysicsObject()->ClearForces();
+                otherObject->GetPhysicsObject()->ClearVelocity();
                 otherObject->GetTransform().SetPosition(otherObject->GetCurrentCheckPointPos());
                 break;
             case TriggerType::CheckPoint:

--- a/Replicated/TriggerVolumeObject.cpp
+++ b/Replicated/TriggerVolumeObject.cpp
@@ -1,9 +1,4 @@
-//
-// Created by c3064585 on 16/02/2024.
-//
-
 #include "TriggerVolumeObject.h"
-#include "PhysicsObject.h"
 
 using namespace NCL::CSC8503;
 
@@ -20,6 +15,7 @@ void TriggerVolumeObject::OnCollisionBegin(GameObject *otherObject) {
                 otherObject->GetPhysicsObject()->ClearForces();
                 otherObject->GetPhysicsObject()->ClearVelocity();
                 otherObject->GetTransform().SetPosition(otherObject->GetCurrentCheckPointPos());
+                //revert camera, function in gameplay state
                 break;
             case TriggerType::CheckPoint:
                 otherObject->SetCurrentCheckPointPos(this->GetTransform().GetPosition());

--- a/Replicated/TriggerVolumeObject.cpp
+++ b/Replicated/TriggerVolumeObject.cpp
@@ -9,6 +9,7 @@ using namespace NCL::CSC8503;
 
 void TriggerVolumeObject::OnCollisionBegin(GameObject *otherObject) {
     if(otherObject->GetIsPlayerBool()){
+        //std::cout << "Player has collided\n";
         switch (triggerType) {
             case TriggerType::Start:
                 std::cout << "Start volume\n";
@@ -27,12 +28,23 @@ void TriggerVolumeObject::OnCollisionBegin(GameObject *otherObject) {
             default:
                     break;
         }
-        std::cout << "Player has collided\n";
     }
 }
 
 void TriggerVolumeObject::OnCollisionEnd(GameObject *otherObject) {
-    if(otherObject->GetIsPlayerBool()){
+    if(otherObject->GetIsPlayerBool()) {
         std::cout << "Collision with player has ended\n";
+        switch (triggerType) {
+            case TriggerType::Start:
+                break;
+            case TriggerType::End:
+                break;
+            case TriggerType::Death:
+                break;
+            case TriggerType::CheckPoint:
+                break;
+            default:
+                break;
+        }
     }
 }

--- a/Replicated/TriggerVolumeObject.h
+++ b/Replicated/TriggerVolumeObject.h
@@ -6,7 +6,6 @@
 #define GITIGNORE_TRIGGERVOLUMEOBJECT_H
 
 #include "GameObject.h"
-#include <iostream>
 
 using namespace NCL;
 using namespace CSC8503;
@@ -27,7 +26,6 @@ public:
 
 private:
     TriggerType triggerType;
-
 };
 
 

--- a/Replicated/TriggerVolumeObject.h
+++ b/Replicated/TriggerVolumeObject.h
@@ -6,6 +6,7 @@
 #define GITIGNORE_TRIGGERVOLUMEOBJECT_H
 
 #include "GameObject.h"
+#include "PhysicsObject.h"
 
 using namespace NCL;
 using namespace CSC8503;

--- a/Replicated/TriggerVolumeObject.h
+++ b/Replicated/TriggerVolumeObject.h
@@ -17,6 +17,7 @@ public:
         Start = 1,
         End = 2,
         Death = 4,
+        CheckPoint = 8,
     };
 
     TriggerVolumeObject(TriggerType triggerEnum) { triggerType = triggerEnum; }

--- a/Server/States/RunningState.cpp
+++ b/Server/States/RunningState.cpp
@@ -169,6 +169,7 @@ void RunningState::AddTriggersToLevel(){
                 colour = {1,0.4f,1,1};
                 break;
             default:
+                colour = {0,0,0,1};
                 break;
         }
         Debug::DrawAABBLines(triggerVec.second, Vector3(5,5,5),

--- a/Server/States/RunningState.cpp
+++ b/Server/States/RunningState.cpp
@@ -154,7 +154,25 @@ void RunningState::AddTriggersToLevel(){
         trigger->GetTransform().SetPosition(triggerVec.second);
         trigger->GetPhysicsObject()->SetIsTriggerVolume(true);
 
-        Debug::DrawAABBLines(triggerVec.second, Vector3(5,5,5), Debug::MAGENTA, 1000.0f);
+        Vector4 colour = Vector4();
+        switch (triggerVec.first){
+            case TriggerVolumeObject::TriggerType::Start:
+                colour = {1,1,1,1};
+                break;
+            case TriggerVolumeObject::TriggerType::End:
+                colour = {0,1,0,1};
+                break;
+            case TriggerVolumeObject::TriggerType::Death:
+                colour = {1,0,0,1};
+                break;
+            case TriggerVolumeObject::TriggerType::CheckPoint:
+                colour = {1,0.4f,1,1};
+                break;
+            default:
+                break;
+        }
+        Debug::DrawAABBLines(triggerVec.second, Vector3(5,5,5),
+                             colour, 1000.0f);
     }
 }
 

--- a/Server/States/RunningState.cpp
+++ b/Server/States/RunningState.cpp
@@ -189,9 +189,12 @@ void RunningState::BuildLevel(const std::string &levelName)
     currentLevelEndPos = levelReader->GetEndPosition();
     currentLevelDeathPos = levelReader->GetDeathBoxPosition();
     triggersVector = {
-            std::make_pair((TriggerVolumeObject::TriggerType)1, currentLevelStartPos),
-            std::make_pair((TriggerVolumeObject::TriggerType)2, currentLevelEndPos),
-            std::make_pair((TriggerVolumeObject::TriggerType)4, currentLevelDeathPos)
+            std::make_pair((TriggerVolumeObject::TriggerType::Start), currentLevelStartPos),
+            std::make_pair((TriggerVolumeObject::TriggerType::End), currentLevelEndPos),
+            std::make_pair((TriggerVolumeObject::TriggerType::Death), currentLevelDeathPos),
+            std::make_pair((TriggerVolumeObject::TriggerType::CheckPoint), Vector3(-62.0f,7.0f,-15.0f)),
+            std::make_pair((TriggerVolumeObject::TriggerType::CheckPoint), Vector3(53.0f,7.0f,-15.0f)),
+            std::make_pair((TriggerVolumeObject::TriggerType::CheckPoint), Vector3(122.0f,7.0f,-15.0f)),
     };
 
     auto plist = levelReader->GetPrimitiveList();


### PR DESCRIPTION
The functionality for the check point system is made from the trigger volume objects I implemented earlier. For example there is a checkpoint trigger volume that when entered, the player's current checkpoint position will be updated. Upon hitting the death trigger volume, the player's forces and velocity are cleared and the player is sent back to the most recently updated checkpoint.

More functionality is required to flesh the game out but that will be decided amongst the group.