### PR TITLE
Added collision layers for raycasts and collisions

### DIFF
--- a/CSC8503CoreClasses/GameWorld.cpp
+++ b/CSC8503CoreClasses/GameWorld.cpp
@@ -97,7 +97,7 @@ void GameWorld::StartWorld() {
 	for (GameObject* gameObject : gameObjects)gameObject->Start();
 }
 
-bool GameWorld::Raycast(Ray& r, RayCollision& closestCollision, bool closestObject, GameObject* ignoreThis) const {
+bool GameWorld::Raycast(Ray& r, RayCollision& closestCollision, bool closestObject, GameObject* ignoreThis,int layerMask) const {
     //The simplest raycast just goes through each object and sees if there's a collision
     RayCollision collision;
 
@@ -108,6 +108,8 @@ bool GameWorld::Raycast(Ray& r, RayCollision& closestCollision, bool closestObje
         if (i == ignoreThis) {
             continue;
         }
+
+        if (!(i->GetPhysicsObject()->GetLayer() & layerMask))continue;
 
         RayCollision thisCollision;
         if (CollisionDetection::RayIntersection(r, *i, thisCollision)) {

--- a/CSC8503CoreClasses/GameWorld.h
+++ b/CSC8503CoreClasses/GameWorld.h
@@ -6,6 +6,7 @@
 #include "CollisionDetection.h"
 #include "QuadTree.h"
 #include "NetworkObject.h"
+#include "PhysicsObject.h"
 namespace NCL {
         class Camera;
         using Maths::Ray;
@@ -42,7 +43,7 @@ namespace NCL {
                 shuffleObjects = state;
             }
 
-            bool Raycast(Ray& r, RayCollision& closestCollision, bool closestObject = false, GameObject* ignore = nullptr) const;
+            bool Raycast(Ray& r, RayCollision& closestCollision, bool closestObject = false, GameObject* ignore = nullptr, int layerMask = ~MAX_LAYER) const;
 
 			virtual void UpdateWorld(float dt);
 			virtual void StartWorld();

--- a/CSC8503CoreClasses/PhysicsObject.h
+++ b/CSC8503CoreClasses/PhysicsObject.h
@@ -8,6 +8,15 @@ namespace NCL {
 	namespace CSC8503 {
 		class Transform;
 
+        enum CollisionLayer {
+            DEFAULT_LAYER = 1,
+            PLAYER_LAYER = 2,
+            TRIGGER_LAYER = 4,
+            STATIC_LAYER = 8,
+            GRAPPLE_LAYER = 16,
+            MAX_LAYER = 32
+        };
+
         //make sure 0.0f< e < 1.0f
         struct PhysicsMaterial {
             float e = 0.8f;
@@ -121,6 +130,10 @@ namespace NCL {
 
             void SetForce(const Vector3 &forceSet);
 
+            CollisionLayer GetLayer() const { return layer; }
+
+            void SetLayer(CollisionLayer l) { layer = l; }
+
 		protected:
 			const CollisionVolume* volume;
 			Transform*		transform;
@@ -138,6 +151,8 @@ namespace NCL {
 			Vector3 torque;
 			Vector3 inverseInertia;
 			Matrix3 inverseInteriaTensor;
+
+            CollisionLayer layer =  DEFAULT_LAYER;
 
             bool isTrigger;
 		};

--- a/CSC8503CoreClasses/PhysicsSystem.cpp
+++ b/CSC8503CoreClasses/PhysicsSystem.cpp
@@ -240,6 +240,8 @@ void PhysicsSystem::BasicCollisionDetection() {
                 continue;
             }
 
+            if (!layerMatrix[(*j)->GetPhysicsObject()->GetLayer() | (*i)->GetPhysicsObject()->GetLayer()])continue;
+
             CollisionDetection::CollisionInfo info;
 
             if(CollisionDetection::ObjectIntersection(*i,*j,info)){

--- a/CSC8503CoreClasses/PhysicsSystem.h
+++ b/CSC8503CoreClasses/PhysicsSystem.h
@@ -5,6 +5,7 @@
 
 namespace NCL {
 	namespace CSC8503 {
+
 		class PhysicsSystem	{
 		public:
 			PhysicsSystem(GameWorld& g);
@@ -79,6 +80,28 @@ namespace NCL {
 
 
       std::unordered_map<std::string, PhysicsMaterial*> physicsMaterials;
+
+      std::unordered_map<int, bool> layerMatrix =
+      { {DEFAULT_LAYER | DEFAULT_LAYER,true},
+          {DEFAULT_LAYER | PLAYER_LAYER,true},
+          {DEFAULT_LAYER | STATIC_LAYER,true},
+          {DEFAULT_LAYER | TRIGGER_LAYER,true},
+          {DEFAULT_LAYER | GRAPPLE_LAYER,true},
+
+          {PLAYER_LAYER | PLAYER_LAYER,true},
+          {PLAYER_LAYER | STATIC_LAYER,true},
+          {PLAYER_LAYER | TRIGGER_LAYER,true},
+          {PLAYER_LAYER | GRAPPLE_LAYER,true},
+
+          {STATIC_LAYER | STATIC_LAYER,false},
+          {STATIC_LAYER | TRIGGER_LAYER,false},
+          {STATIC_LAYER | GRAPPLE_LAYER,true},
+
+          {TRIGGER_LAYER | TRIGGER_LAYER,false},
+          {TRIGGER_LAYER | GRAPPLE_LAYER,false},
+
+          {GRAPPLE_LAYER | GRAPPLE_LAYER,false}
+      };
 
 		};
 	}

--- a/Server/Components/PlayerMovement.cpp
+++ b/Server/Components/PlayerMovement.cpp
@@ -240,7 +240,7 @@ void PlayerMovement::UpdateGrapple(float dt) {
     grappleProjectileInfo.travelDistance += grappleProjectileInfo.travelSpeed * dt;
 
     RayCollision collision;
-    if (world->Raycast(grappleProjectileInfo.grappleRay, collision, true, gameObject)) {
+    if (world->Raycast(grappleProjectileInfo.grappleRay, collision, true, gameObject, TRIGGER_LAYER ^ ~MAX_LAYER)) {
         auto tempGrapplePoint = collision.collidedAt;
         if ((grappleProjectileInfo.grappleRay.GetPosition() - tempGrapplePoint).Length() < grappleProjectileInfo.travelDistance) {
             grapplePoint = tempGrapplePoint;

--- a/Server/States/RunningState.cpp
+++ b/Server/States/RunningState.cpp
@@ -130,6 +130,7 @@ void RunningState::CreatePlayers() {
         player->GetPhysicsObject()->SetInverseMass(2.0f);
         player->GetPhysicsObject()->InitSphereInertia();
         player->GetPhysicsObject()->SetPhysMat(physics->GetPhysMat("Player"));
+        player->GetPhysicsObject()->SetLayer(PLAYER_LAYER);
         player->SetTag(Tag::PLAYER);
 
         //TODO: clean up
@@ -152,6 +153,8 @@ void RunningState::AddTriggersToLevel(){
         trigger->GetPhysicsObject()->SetInverseMass(0.0f);
         trigger->GetTransform().SetPosition(triggerVec.second);
         trigger->GetPhysicsObject()->SetIsTriggerVolume(true);
+        trigger->GetPhysicsObject()->SetLayer(TRIGGER_LAYER);
+
 
         Vector4 colour = Vector4();
         switch (triggerVec.first){
@@ -256,6 +259,8 @@ void RunningState::BuildLevel(const std::string &levelName)
         replicated->AddBlockToLevel(g, *world, x);
         g->SetPhysicsObject(new PhysicsObject(&g->GetTransform(), g->GetBoundingVolume(), new PhysicsMaterial()));
         g->GetPhysicsObject()->SetInverseMass(0.0f);
+        g->GetPhysicsObject()->SetLayer(STATIC_LAYER);
+
     }
 
     //SetTestSprings();


### PR DESCRIPTION
-Raycast function can now take input for the layer mask the raycast should collide with. Look at PlayerMovement::UpdateGrapple() for an example.
- Collision detection is ignored with layers that should not collide, as defined in layerMatrix in PhysicsSystem.h