### PR TITLE
Camera sway changes

### DIFF
--- a/Client/States/GameplayState.cpp
+++ b/Client/States/GameplayState.cpp
@@ -203,6 +203,12 @@ void GameplayState::ReadNetworkFunctions() {
                 strafeSpeed = strfSpd;
             }
             break;
+
+            case(Replicated::Grapple_Event): {
+                int eventType = handler.Unpack<int>();
+                HandleGrappleEvent(eventType);
+            }
+            break;
         }
 
     }
@@ -227,6 +233,19 @@ void GameplayState::WalkCamera(float dt) {
 void GameplayState::JumpCamera(float dt) {
     world->GetMainCamera()->SetOffsetPosition(world->GetMainCamera()->GetOffsetPosition() + Vector3(0, -jumpBobAmount * sin(PI - jumpTimer), 0));
     jumpTimer = std::clamp(jumpTimer - dt * jumpAnimationSpeed, 0.0f, PI);
+}
+
+void GameplayState::HandleGrappleEvent(int event) {
+    switch (event) {
+        case 1: {
+            strafeTiltAmount = strafeTiltAmountGrappling;
+            break;
+        }
+        case 2: {
+            strafeTiltAmount = strafeTiltAmountGrounded;
+           break;
+        }
+    }
 }
 
 void GameplayState::LandCamera(float dt) {

--- a/Client/States/GameplayState.cpp
+++ b/Client/States/GameplayState.cpp
@@ -236,13 +236,12 @@ void GameplayState::JumpCamera(float dt) {
 }
 
 void GameplayState::HandleGrappleEvent(int event) {
+    //does nothing currently, use this to do visuals or sound or whatever
     switch (event) {
         case 1: {
-            strafeTiltAmount = strafeTiltAmountGrappling;
             break;
         }
         case 2: {
-            strafeTiltAmount = strafeTiltAmountGrounded;
            break;
         }
     }

--- a/Client/States/GameplayState.h
+++ b/Client/States/GameplayState.h
@@ -125,8 +125,6 @@ namespace NCL {
             float strafeAmount = 0.0f;
             const float strafeSpeedMax = 12.0f;
             float strafeTiltAmount = 1.0f;
-            const float strafeTiltAmountGrounded = 1.0f;
-            const float strafeTiltAmountGrappling = 15.0f;
 
             void HandleGrappleEvent(int event);
 

--- a/Client/States/GameplayState.h
+++ b/Client/States/GameplayState.h
@@ -90,6 +90,7 @@ namespace NCL {
 
             void ReadNetworkFunctions();
 
+
             void ReadNetworkPackets();
 
             void ResetCameraAnimation();
@@ -105,6 +106,7 @@ namespace NCL {
             float walkSoundTimer = 0.0f;
 
             bool isGrounded = false;
+            bool isGrappling = false;
 
             void JumpCamera(float dt);
             float jumpTimer = 0.0f;
@@ -122,7 +124,11 @@ namespace NCL {
             float strafeSpeed = 0.0f;
             float strafeAmount = 0.0f;
             const float strafeSpeedMax = 12.0f;
-            const float strafeTiltAmount = 1.0f;
+            float strafeTiltAmount = 1.0f;
+            const float strafeTiltAmountGrounded = 1.0f;
+            const float strafeTiltAmountGrappling = 15.0f;
+
+            void HandleGrappleEvent(int event);
 
             float levelLen;
             Vector3 startPos;

--- a/Replicated/Replicated.h
+++ b/Replicated/Replicated.h
@@ -28,7 +28,8 @@ public:
         Camera_GroundedMove,
         Camera_Jump,
         Camera_Land,
-        Camera_Strafe
+        Camera_Strafe,
+        Grapple_Event
     };
 
     // In the situation where the server is the remote (Client to server)

--- a/Server/Components/PlayerMovement.cpp
+++ b/Server/Components/PlayerMovement.cpp
@@ -56,11 +56,13 @@ void PlayerMovement::SwitchToState(MovementState* state) {
 }
 
 void PlayerMovement::OnGrappleLeave() {
-    cameraAnimationCalls.grapplingState = 2;
+    cameraAnimationCalls.isGrappling = false;
+    cameraAnimationCalls.grapplingEvent = 2;
 }
 
 void PlayerMovement::OnGrappleStart() {
-    cameraAnimationCalls.grapplingState = 1;
+    cameraAnimationCalls.isGrappling = true;
+    cameraAnimationCalls.grapplingEvent = 1;
     StartInAir();
 }
 

--- a/Server/Components/PlayerMovement.cpp
+++ b/Server/Components/PlayerMovement.cpp
@@ -56,10 +56,11 @@ void PlayerMovement::SwitchToState(MovementState* state) {
 }
 
 void PlayerMovement::OnGrappleLeave() {
-
+    cameraAnimationCalls.grapplingState = 2;
 }
 
 void PlayerMovement::OnGrappleStart() {
+    cameraAnimationCalls.grapplingState = 1;
     StartInAir();
 }
 
@@ -259,6 +260,7 @@ void PlayerMovement::UpdateGrapple(float dt) {
 }
 
 void PlayerMovement::FireGrapple() {
+    
     SwitchToState(&grapple);
 //    float gravity = -9.8;
 //

--- a/Server/Components/PlayerMovement.h
+++ b/Server/Components/PlayerMovement.h
@@ -37,7 +37,8 @@ public:
         float groundMovement = 0.0f;
         float strafeSpeed = 0.0f;
         float shakeIntensity = 0.0f;
-        int grapplingState = 0; //0 is nothing has happened, 1 is start grapple, 2 is end grapple.
+        int grapplingEvent = 0; //0 is nothing has happened, 1 is start grapple, 2 is end grapple.
+        bool isGrappling = false;
     };
 
     CameraAnimationCallData cameraAnimationCalls;

--- a/Server/Components/PlayerMovement.h
+++ b/Server/Components/PlayerMovement.h
@@ -37,6 +37,7 @@ public:
         float groundMovement = 0.0f;
         float strafeSpeed = 0.0f;
         float shakeIntensity = 0.0f;
+        int grapplingState = 0; //0 is nothing has happened, 1 is start grapple, 2 is end grapple.
     };
 
     CameraAnimationCallData cameraAnimationCalls;

--- a/Server/States/RunningState.cpp
+++ b/Server/States/RunningState.cpp
@@ -236,6 +236,16 @@ void RunningState::UpdatePlayerMovement(GameObject* player, const InputPacket& i
         handler.Pack(playerMovement->cameraAnimationCalls.strafeSpeed);
         networkData->outgoingFunctions.Push(std::make_pair(id, FunctionPacket(Replicated::Camera_Strafe, &data)));
     }
+
+    if ( int state = playerMovement->cameraAnimationCalls.grapplingState != 0) {
+        auto id = GetIdFromPlayerObject(player);
+        FunctionData data;
+        DataHandler handler(&data);
+        handler.Pack(playerMovement->cameraAnimationCalls.grapplingState);
+        networkData->outgoingFunctions.Push(std::make_pair(id, FunctionPacket( Replicated::Grapple_Event , &data)));
+        playerMovement->cameraAnimationCalls.grapplingState = 0;
+
+    }
     
 }
 

--- a/Server/States/RunningState.cpp
+++ b/Server/States/RunningState.cpp
@@ -2,6 +2,8 @@
 using namespace NCL;
 using namespace CSC8503;
 
+#define GRAPPLE_SWAY_MULTIPLIER 15.0f
+
 RunningState::RunningState(GameServer* pBaseServer) : State() {
     // Don't use serverBase without talking to other members of the team.
     serverBase = pBaseServer;
@@ -233,17 +235,18 @@ void RunningState::UpdatePlayerMovement(GameObject* player, const InputPacket& i
         auto id = GetIdFromPlayerObject(player);
         FunctionData data;
         DataHandler handler(&data);
-        handler.Pack(playerMovement->cameraAnimationCalls.strafeSpeed);
+        float speed = playerMovement->cameraAnimationCalls.strafeSpeed * (playerMovement->cameraAnimationCalls.isGrappling ? GRAPPLE_SWAY_MULTIPLIER:1.0f);
+        handler.Pack(speed);
         networkData->outgoingFunctions.Push(std::make_pair(id, FunctionPacket(Replicated::Camera_Strafe, &data)));
     }
 
-    if ( int state = playerMovement->cameraAnimationCalls.grapplingState != 0) {
+    if ( int state = playerMovement->cameraAnimationCalls.grapplingEvent != 0) {
         auto id = GetIdFromPlayerObject(player);
         FunctionData data;
         DataHandler handler(&data);
-        handler.Pack(playerMovement->cameraAnimationCalls.grapplingState);
+        handler.Pack(playerMovement->cameraAnimationCalls.grapplingEvent);
         networkData->outgoingFunctions.Push(std::make_pair(id, FunctionPacket( Replicated::Grapple_Event , &data)));
-        playerMovement->cameraAnimationCalls.grapplingState = 0;
+        playerMovement->cameraAnimationCalls.grapplingEvent = 0;
 
     }
     


### PR DESCRIPTION
- Camera now sways more when grappling, done by modifying the Camera_strafe packet to be larger if the player is grappling.
- Also added a grapplingEvent replicated function, so code can be executed client side when the player starts to grapple or when the player stops their grapple.