### PR TITLE
Countdown timer for server & client

### DIFF
--- a/Client/States/GameplayState.cpp
+++ b/Client/States/GameplayState.cpp
@@ -196,7 +196,6 @@ void GameplayState::Update(float dt) {
     }
     bool countdownOver = levelManager->UpdateCountdown(dt); 
     float countdownTimer = levelManager->GetCountdown(); //this could be used to display a countdown on screen, for example.
-    if(!countdownOver)std::cout << countdownTimer << "\n";
 
     totalDTElapsed += dt;
     ResetCameraAnimation();

--- a/Client/States/GameplayState.cpp
+++ b/Client/States/GameplayState.cpp
@@ -194,6 +194,9 @@ void GameplayState::Update(float dt) {
         ManageLoading(dt);
         return;
     }
+    bool countdownOver = levelManager->UpdateCountdown(dt); 
+    float countdownTimer = levelManager->GetCountdown(); //this could be used to display a countdown on screen, for example.
+
     totalDTElapsed += dt;
     ResetCameraAnimation();
     SendInputData();
@@ -211,7 +214,7 @@ void GameplayState::Update(float dt) {
     StrafeCamera(dt);
 
     world->GetMainCamera()->UpdateCamera(dt);
-    world->UpdateWorld(dt);
+    if(countdownOver)world->UpdateWorld(dt);
 
     ReadNetworkPackets();
 

--- a/Client/States/GameplayState.cpp
+++ b/Client/States/GameplayState.cpp
@@ -196,6 +196,7 @@ void GameplayState::Update(float dt) {
     }
     bool countdownOver = levelManager->UpdateCountdown(dt); 
     float countdownTimer = levelManager->GetCountdown(); //this could be used to display a countdown on screen, for example.
+    if(!countdownOver)std::cout << countdownTimer << "\n";
 
     totalDTElapsed += dt;
     ResetCameraAnimation();

--- a/Client/States/GameplayState.cpp
+++ b/Client/States/GameplayState.cpp
@@ -466,8 +466,11 @@ void GameplayState::SendInputData() {
 }
 
 void GameplayState::FinishLoading() {
-    networkData->outgoingFunctions.Push(FunctionPacket(Replicated::GameLoaded, nullptr));
+    while (worldHasLoaded != LoadingStates::LOADED || soundHasLoaded != LoadingStates::LOADED) { 
+    }
     world->StartWorld();
+    networkData->outgoingFunctions.Push(FunctionPacket(Replicated::GameLoaded, nullptr));
+
 }
 
 void GameplayState::InitCamera() {

--- a/Client/States/GameplayState.cpp
+++ b/Client/States/GameplayState.cpp
@@ -199,7 +199,7 @@ void GameplayState::Update(float dt) {
 
     totalDTElapsed += dt;
     ResetCameraAnimation();
-    SendInputData();
+    if(countdownOver)SendInputData();
     ReadNetworkFunctions();
 
     Window::GetWindow()->ShowOSPointer(false);

--- a/Server/Components/PlayerMovement.cpp
+++ b/Server/Components/PlayerMovement.cpp
@@ -12,7 +12,7 @@ PlayerMovement::PlayerMovement(GameObject *g, GameWorld *w) {
     gameObject = g;
 
     runSpeed = 5000.0f;
-    jumpVelocity = 500.0f;
+    jumpVelocity = 0.0f;
 
     dragFactor = 10.0f;
     coyoteTime = 0.5f;

--- a/Server/Levels/LevelManager.cpp
+++ b/Server/Levels/LevelManager.cpp
@@ -15,6 +15,11 @@ void LevelManager::UpdateTimer(float dt) {
     stageTimer->Update(dt);
 }
 
+bool LevelManager::UpdateCountdown(float dt) {
+    countdownTimer -= dt;
+    return countdownTimer <= 0.0f;
+}
+
 void LevelManager::StartStageTimer() {
     stageTimer->ResetTimer();
     stageTimer->ResumeTimer();

--- a/Server/Levels/LevelManager.h
+++ b/Server/Levels/LevelManager.h
@@ -4,6 +4,7 @@
 
 #ifndef SPEEDFUN_LEVELMANAGER_H
 #define SPEEDFUN_LEVELMANAGER_H
+#define COUNTDOWN_MAX 5.0f
 
 #include <iostream>
 #include "LevelReader.h"
@@ -15,8 +16,13 @@ public:
     void UpdateTimer(float dt);
     bool TryReadLevel(std::string levelSource);
 
+    bool UpdateCountdown(float dt);
+    void ResetCountdown() { countdownTimer = COUNTDOWN_MAX; }
+    float GetCountdown() { return countdownTimer; }
+
     void StartStageTimer();
     void EndStageTimer();
+
     int GetCurrentMedal() const;
     Vector4 GetCurrentMedalColour() const;
 
@@ -26,6 +32,7 @@ protected:
 
     std::shared_ptr<LevelReader> levelReader;
     std::unique_ptr<StageTimer> stageTimer;
+    float countdownTimer = COUNTDOWN_MAX;
     int currentTimer;
 
     struct {

--- a/Server/States/RunningState.cpp
+++ b/Server/States/RunningState.cpp
@@ -109,15 +109,15 @@ void RunningState::Update(float dt) {
     ReadNetworkFunctions();
     ReadNetworkPackets();
     UpdatePlayerAnimations();
-    if (countdownTimer == 5.0f) {//i.e only once, do this so player positions are correct.
+    if (levelManager->GetCountdown() == COUNTDOWN_MAX) {//i.e only once, do this so player positions are correct.
         Tick(dt);
     }
 
-    if (countdownTimer > 0) {
-        countdownTimer -= dt;
-        std::cout << countdownTimer << "\n";
+    if (!levelManager->UpdateCountdown(dt)) {
+        std::cout << levelManager->GetCountdown() << "\n";
         return;
     }
+
     world->UpdateWorld(dt);
     physics->Update(dt);
     Tick(dt);

--- a/Server/States/RunningState.cpp
+++ b/Server/States/RunningState.cpp
@@ -114,7 +114,6 @@ void RunningState::Update(float dt) {
     }
 
     if (!levelManager->UpdateCountdown(dt)) {
-        std::cout << levelManager->GetCountdown() << "\n";
         return;
     }
 

--- a/Server/States/RunningState.h
+++ b/Server/States/RunningState.h
@@ -62,11 +62,13 @@ namespace NCL {
 
             std::atomic<bool> shouldClose;
 
+            float countdownTimer = 5.0f;
             float packetTimer;
             int sceneSnapshotId;
 
             int playerTestId = -1;
 
+            int numPlayersLoaded = 0;
             std::unordered_map<int, GameObject*> playerObjects;
 
             void LoadLevel();

--- a/Server/States/RunningState.h
+++ b/Server/States/RunningState.h
@@ -69,6 +69,7 @@ namespace NCL {
 
             int numPlayersLoaded = 0;
             std::unordered_map<int, GameObject*> playerObjects;
+            bool isGameInProgress = false;
 
             void LoadLevel();
             void BuildLevel(const std::string &levelName);

--- a/Server/States/RunningState.h
+++ b/Server/States/RunningState.h
@@ -62,7 +62,6 @@ namespace NCL {
 
             std::atomic<bool> shouldClose;
 
-            float countdownTimer = 5.0f;
             float packetTimer;
             int sceneSnapshotId;
 


### PR DESCRIPTION
- The game now waits until all players have loaded the game to begin.
- When all players have loaded, it starts a countdown timer, and then the game only starts once the timer has expired.
- The countdown is managed in LevelManager and the value/state of the countdown can be acted upon in GameplayState or RunningState.