### PR TITLE
Grapple deactivates when the player falls off the map

### DIFF
--- a/CSC8503CoreClasses/PhysicsSystem.cpp
+++ b/CSC8503CoreClasses/PhysicsSystem.cpp
@@ -17,7 +17,7 @@ using namespace CSC8503;
 
 PhysicsSystem::PhysicsSystem(GameWorld& g) : gameWorld(g)	{
 	applyGravity	= true;
-	useBroadPhase	= true;	
+	useBroadPhase	= false;	
 	dTOffset		= 0.0f;
 	globalDamping	= 0.995f;
 	SetGravity(Vector3(0.0f, -13.0f, 0.0f));

--- a/Server/Components/PlayerMovement.h
+++ b/Server/Components/PlayerMovement.h
@@ -56,6 +56,26 @@ public:
     PlayerAnimationCallData playerAnimationCallData;
 
     void ToggleDebug() { debugEnabled = !debugEnabled; }
+
+    struct GrappleInfo {
+        Ray grappleRay;
+        float travelDistance;
+        float travelSpeed;
+        float maxDistance;
+
+        void SetActive(bool active) {
+            isActive = active;
+        }
+
+        bool GetActive() {
+            return isActive;
+        }
+    private:
+        bool isActive;
+    } grappleProjectileInfo;
+
+    void LeaveGrappleState() { SwitchToState(&air); }
+
 private:
     GameWorld* world;
 
@@ -79,22 +99,6 @@ private:
     float fallApex = 0.0f;
     bool isFalling = false;
 
-    struct GrappleInfo {
-        Ray grappleRay;
-        float travelDistance;
-        float travelSpeed;
-        float maxDistance;
-
-        void SetActive(bool active) {
-            isActive = active;
-        }
-
-        bool GetActive() {
-            return isActive;
-        }
-    private:
-        bool isActive;
-    } grappleProjectileInfo;
 
     Vector3 grapplePoint;
 

--- a/Server/States/RunningState.cpp
+++ b/Server/States/RunningState.cpp
@@ -1,5 +1,6 @@
 #include "RunningState.h"
 #include "RunningState.h"
+#include "RunningState.h"
 using namespace NCL;
 using namespace CSC8503;
 
@@ -214,6 +215,7 @@ void RunningState::EndTriggerVolFunc(int id){
 }
 
 void RunningState::DeathTriggerVolFunc(int id){
+    CancelGrapple(id);
     FunctionData data;
     DataHandler handler(&data);
     handler.Pack(id);
@@ -460,6 +462,17 @@ void RunningState::SetTriggerTypePositions(){
     };
     for (auto checkpoint : currentLevelCheckPointPositions) {
         triggersVector.emplace_back(std::make_pair((TriggerVolumeObject::TriggerType::CheckPoint), checkpoint));
+    }
+}
+
+void RunningState::CancelGrapple(int id)
+{
+    auto player = GetPlayerObjectFromId(id);
+    PlayerMovement* playerMovement;
+    if (player->TryGetComponent(playerMovement)) {
+        playerMovement->grappleProjectileInfo.SetActive(false);
+        playerMovement->grappleProjectileInfo.travelDistance = 0;
+        playerMovement->LeaveGrappleState();
     }
 }
 

--- a/Server/States/RunningState.h
+++ b/Server/States/RunningState.h
@@ -111,6 +111,8 @@ namespace NCL {
 
             void SetTriggerTypePositions();
 
+            void CancelGrapple(int id);
+
         };
     }
 }


### PR DESCRIPTION
The grapple will reset when:

- Player reaches death plane while in grapple
- Player fires a grapple and hits the death plane before the grapple hits

The projectile info struct stuff is public now, but shouldn't be an issue.